### PR TITLE
Преобразование нечитаемых якорных ссылок в короткие и удобные

### DIFF
--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -29,6 +29,11 @@ export default defineConfigWithTheme<DocsTheme.Config>({
     config (md) {
       containerPlugin(md)
     },
+    anchor: {
+      slugify(str) {
+          return encodeURIComponent('s')// s = section
+      }
+    },
   },
 
   head: [


### PR DESCRIPTION
## Описание улучшений

Данный PR реализует преобразование якорных ссылок из формата:
/Docs/components/pdotools/parser#%D0%BE%D0%B1%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-%D1%87%D0%B0%D0%BD%D0%BA%D0%B0

_(это /Docs/components/pdotools/parser#обработка-страницы ,только urlencoded)_

в формат коротких URL вида: 
/Docs/components/pdotools/parser#s-7

s — означает section. Выбирал межу s и h, потому что heading вроде логично, то чтобы никто не путался в понятиях уровней HTML заголовков h1-h5 и наших секций в документации, выбрал именно "s". К тому же s ближе к цифрам на клавиатуре, и s-3 легче набирать, чем h-3 например.

### Возможные вопросы и ответы на них
- Выбрать что-то, кроме буквы префиксом для якоря, нельзя, т.к. будет не валидный id с точки зрения JS. 

- Убрать "-" можно кажется только через правку ядра, но имхо оно того не стоит.

При этом, в соответствии с [документацией vitepress](https://vitepress.dev/guide/markdown#header-anchors) у автора остаётся возможность дописать свой якорь к заголовку (я сделал это для двух компонентов, Scheduler и AjaxFormItLogin в моём соседнем PR для демонстрации, ну и другие коллеги уже пользуются, например /Docs/system/basics/modifiers/string#nl2br)
