### PR TITLE
Добавление лайтбокса к изображениям

### DIFF
--- a/docs/.vitepress/theme/components/DocsDocFooter.vue
+++ b/docs/.vitepress/theme/components/DocsDocFooter.vue
@@ -35,39 +35,74 @@ const showFooter = computed(() => {
         document[where].append(link);
 
     };
+
     let GoLoadJS = function(path, where='body') {
         let script = document.createElement('script');
             script.src = path;
         document[where].append(script);
     };
     //TODO подписать этот кусок кода на готовность VUE потому что не будет работать, если убрать таймаут
+    let handleLinkClick = function(event){
+        event.preventDefault();
+        console.log('click '+this.src);
+        console.log('click '+this.href);
+        let docGallery = GLightbox({
+            // reference: https://github.com/biati-digital/glightbox#lightbox-options
+            elements: [
+                {
+                    'href': this.href,
+                    'type': 'image',
+                    'title': this.title,
+                    //'description': 'Example',
+                },
+                //TODO собрать галерею из всех ссылок и картинок, а по клику открывать нужную. Чтобы можно было листать.
+            ],
+            autoplayVideos: true,
+        });
+        docGallery.open();
+    }
+
+    let handleImageClick = function(){
+        //console.log('click '+this.src);
+        let docGallery = GLightbox({
+            // reference: https://github.com/biati-digital/glightbox#lightbox-options
+            elements: [
+                {
+                    'href': this.src,
+                    'type': 'image',
+                    'title': this.alt,
+                    //'description': 'Example',
+                },
+                //TODO собрать галерею из всех картинок, а по клику открывать нужную. Чтобы можно было листать.
+            ],
+            autoplayVideos: true,
+        });
+        docGallery.open();
+    }
+
     window.setTimeout(()=>{
         GoLoadJS("https://cdn.jsdelivr.net/gh/mcstudios/glightbox/dist/js/glightbox.min.js");
         GoLoadCSS("https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css");
-        let imgs = document.querySelectorAll('.vp-doc img');
+
+        let imgs = document.querySelectorAll('.vp-doc :not(:is(a)) img');
         for (let img of imgs) {
-            img.addEventListener( 'click', function(){
-                console.log('click '+this.src);
-                let docGallery = GLightbox({
-                    // reference: https://github.com/biati-digital/glightbox#lightbox-options
-                    elements: [
-                        {
-                            'href': this.src,
-                            'type': 'image',
-                            'title': this.alt,
-                            //'description': 'Example',
-                        },
-                        //TODO собрать галерею из всех картинок, а по клику открывать нужную. Чтобы можно было листать.
-                    ],
-                    autoplayVideos: true,
-                });
-                docGallery.open();
-            })
+            img.addEventListener('click', handleImageClick)
         }
+
+        let links = document.querySelectorAll('.vp-doc a[href$=".png"]');
+
+        for (let link of links) {
+            link.addEventListener('click', handleLinkClick)
+
+            //убираеми обработку клика на дочерние картинки, раз ссылка есть
+            let imgs = link.querySelectorAll('img');
+            for (let img of imgs) {
+                img.removeEventListener('click', handleImageClick);
+            }
+        }
+
     }, 1500);//если сильно переживаем за первую загрузку TODO проверить cookie или еще что-нибудь, чтобы убрать таймаут для повторных загрузок
 
-    //TODO обрабатывать ссылки, типа как во 2й картинке здесь: https://docs.modx.pro/components/amocrm/webhook
-    //https://github.com/modx-pro/Docs/edit/master/docs/components/amocrm/webhook.md
 </script>
 
 <template>

--- a/docs/.vitepress/theme/components/DocsDocFooter.vue
+++ b/docs/.vitepress/theme/components/DocsDocFooter.vue
@@ -27,6 +27,49 @@ const showFooter = computed(() => {
 })
 </script>
 
+<script lang="ts">
+    let GoLoadCSS = function(path, where='head') {
+        let link = document.createElement('link');
+        link.rel = "stylesheet";
+        link.href = path;
+        document[where].append(link);
+
+    };
+    let GoLoadJS = function(path, where='body') {
+        let script = document.createElement('script');
+            script.src = path;
+        document[where].append(script);
+    };
+    //TODO подписать этот кусок кода на готовность VUE потому что не будет работать, если убрать таймаут
+    window.setTimeout(()=>{
+        GoLoadJS("https://cdn.jsdelivr.net/gh/mcstudios/glightbox/dist/js/glightbox.min.js");
+        GoLoadCSS("https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css");
+        let imgs = document.querySelectorAll('.vp-doc img');
+        for (let img of imgs) {
+            img.addEventListener( 'click', function(){
+                console.log('click '+this.src);
+                let docGallery = GLightbox({
+                    // reference: https://github.com/biati-digital/glightbox#lightbox-options
+                    elements: [
+                        {
+                            'href': this.src,
+                            'type': 'image',
+                            'title': this.alt,
+                            //'description': 'Example',
+                        },
+                        //TODO собрать галерею из всех картинок, а по клику открывать нужную. Чтобы можно было листать.
+                    ],
+                    autoplayVideos: true,
+                });
+                docGallery.open();
+            })
+        }
+    }, 1500);//если сильно переживаем за первую загрузку TODO проверить cookie или еще что-нибудь, чтобы убрать таймаут для повторных загрузок
+
+    //TODO обрабатывать ссылки, типа как во 2й картинке здесь: https://docs.modx.pro/components/amocrm/webhook
+    //https://github.com/modx-pro/Docs/edit/master/docs/components/amocrm/webhook.md
+</script>
+
 <template>
   <footer v-if="showFooter" class="VPDocFooter">
     <slot name="doc-footer-before" />
@@ -60,6 +103,24 @@ const showFooter = computed(() => {
     </div>
   </footer>
 </template>
+
+<style>
+/*Кстомизация для лайтбокса TODO вынести отсюда в правильнео место и/или заменить на css-переменные*/
+.vp-doc img{
+    cursor: pointer;
+}
+.glightbox-open{
+    overflow: auto !important;
+}
+.glightbox-clean .gslide-description {
+    background: none !important;
+}
+.gslide-title{
+    color: #10b981 !important;
+    margin-bottom: 0 !important;
+    text-align: center;
+}
+</style>
 
 <style scoped>
 .VPDocFooter {


### PR DESCRIPTION
## Описание улучшений

Данный PR добавляет удобный лайтбокс для просмотра увеличенных изображений

## Актуальные проблемы

В документации много изображений, которые сложно рассмотреть без увеличения, например [в компоненте office](https://docs.modx.pro/components/office/quick-start) или [msearch2](https://docs.modx.pro/components/msearch2/interface/search) , [msextrafields ](https://docs.modx.pro/components/msextrafields/interface) и так далее 

Вот так будет выглядеть (на момент создания черновика PR)

[moxi big image lightbox.webm](https://github.com/modx-pro/Docs/assets/5102558/198f0b2f-3b97-45ba-b2c5-f9fcededae90)

[lightbox with title.webm](https://github.com/modx-pro/Docs/assets/5102558/ff57bd1f-10fb-45fb-a27f-108101e3aea8)

[mob lightbox.webm](https://github.com/modx-pro/Docs/assets/5102558/a109ffd2-5415-4ab9-8317-7f4ead0da3a2)

[office pc lightbox.webm](https://github.com/modx-pro/Docs/assets/5102558/c00a4dc2-15a1-4475-8143-68d61cb3f369)
