### PR TITLE
docs(mxlogger): зависимость MODX 3 от VueTools

### DIFF
--- a/docs/components/mxlogger/index.md
+++ b/docs/components/mxlogger/index.md
@@ -55,7 +55,16 @@ items: [
 | PHP | 7.4+ | 8.1+ |
 | СУБД | MySQL 5.6+ / MariaDB на InnoDB (FULLTEXT-индекс по тэгам; таблица в utf8mb4) | то же |
 | расширения PHP | PDO, mbstring, json | то же |
+| пакет интерфейса | — | **[VueTools](https://modstore.pro/packages/development/vuetools)** (обязателен) |
 | плагин магазина (опц.) | miniShop2 | miniShop3 |
+
+::: warning Зависимость MODX 3: VueTools
+Менеджерный грид версии под **MODX 3** построен на Vue 3 + PrimeVue и берёт этот
+стек из общего пакета **[VueTools](https://modstore.pro/packages/development/vuetools)**
+(через ES Module Import Map) — он **обязателен**. Без установленного VueTools страница
+журнала покажет сообщение о необходимости его установить. В версии под **MODX 2**
+(грид на ExtJS) VueTools не нужен.
+:::
 
 ## Установка
 
@@ -63,6 +72,11 @@ items: [
 (utf8mb4), namespace `mxlogger`, меню «Компоненты → mxLogger», системные настройки,
 сниппет `mxLogger`, плагины `mxLoggerRotate` (ротация) и плагин логирования магазина
 (`mxLoggerMiniShop2` в версии под MODX 2 / `mxLoggerMiniShop3` под MODX 3).
+
+::: tip MODX 3
+Перед установкой убедитесь, что установлен пакет **VueTools** — он поставляет общий
+Vue/PrimeVue для менеджерного грида.
+:::
 
 ## Быстрый старт
 

--- a/docs/components/mxlogger/manager.md
+++ b/docs/components/mxlogger/manager.md
@@ -6,8 +6,9 @@
 
 ::: info Технология грида
 
-- **MODX 3** — грид на Vue 3 + PrimeVue.
-- **MODX 2** — CMP-грид на ExtJS (MODExt).
+- **MODX 3** — грид на Vue 3 + PrimeVue; стек берётся из пакета
+  **[VueTools](https://modstore.pro/packages/development/vuetools)** (обязателен).
+- **MODX 2** — CMP-грид на ExtJS (MODExt), без внешних зависимостей.
 
 Набор фильтров, колонок и действий — одинаковый.
 :::


### PR DESCRIPTION
Версия mxLogger под MODX 3 (Vue3+PrimeVue грид) берёт стек из пакета VueTools и требует его установки. Добавлено в «Требования» (строка таблицы + warning) и «Технологию грида» (manager.md). В MODX 2 (ExtJS) зависимости нет.

Догоняет уже смерженный #922 (правка не успела попасть в него).