### PR TITLE
fix(msyandexdelivery): указать автора ibochkarev в index RU/EN

### DIFF
--- a/docs/components/msyandexdelivery/index.md
+++ b/docs/components/msyandexdelivery/index.md
@@ -1,7 +1,7 @@
 ---
 title: msYandexDelivery
 description: Доставка через Yandex Delivery Platform API (other-day) для MiniShop3 — расчёт, ПВЗ, заявки в менеджере
-author: modx-pro
+author: ibochkarev
 dependencies: [miniShop3, VueTools]
 categories: minishop3
 logo: https://modstore.pro/assets/extras/msyandexdelivery/logo-md.png

--- a/docs/en/components/msyandexdelivery/index.md
+++ b/docs/en/components/msyandexdelivery/index.md
@@ -1,7 +1,7 @@
 ---
 title: msYandexDelivery
 description: Yandex Delivery Platform API (other-day) for MiniShop3 — rates, pickup points, manager requests
-author: modx-pro
+author: ibochkarev
 dependencies: [miniShop3, VueTools]
 categories: minishop3
 logo: https://modstore.pro/assets/extras/msyandexdelivery/logo-md.png


### PR DESCRIPTION
В frontmatter `index.md` msYandexDelivery поле `author` заменено с `modx-pro` на `ibochkarev` в RU и EN. Логин есть в `docs/authors.json`, карточка компонента на сайте показывает автора пакета, а не организацию.

Других правок в документации нет.