### PR TITLE
docs(geolocation2): добавить документацию компонента

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1098,7 +1098,20 @@
     "yandexdelivery",
     "postpay",
     "card_on_receipt",
-    "already_paid"
+    "already_paid",
+    "geolocation2",
+    "geolocation",
+    "sxgeo",
+    "sypexgeo",
+    "модалка",
+    "модалку",
+    "Модалка",
+    "закэшированных",
+    "Автопоказ",
+    "Геоданные",
+    "jsdelivr",
+    "liveupdate",
+    "модалкой"
   ],
   "ignorePaths": [
     "node_modules",

--- a/docs/components/geolocation2/api-action.md
+++ b/docs/components/geolocation2/api-action.md
@@ -1,0 +1,146 @@
+---
+title: Web API (action.php)
+description: REST-эндпоинт GeoLocation2 — state, data, search, save, confirm, dismiss
+---
+
+# Web API (action.php)
+
+URL:
+
+```text
+/assets/components/geolocation2/action.php
+```
+
+Ответ всегда JSON. Запросы отправляйте с заголовком `X-Requested-With: XMLHttpRequest`.
+
+При `geolocation2_debug = 1` подробности могут попадать в MODX error log.
+
+## CSRF
+
+POST (`save`, `confirm`, `dismiss`) требуют поле `csrf` из плейсхолдера `gl2_csrf` (сессия). Токен выставляет сниппет модалки и отдаёт `action=state`.
+
+## GET
+
+### `action=state`
+
+Текущее состояние без изменения сессии.
+
+```http
+GET /assets/components/geolocation2/action.php?action=state
+```
+
+Пример ответа:
+
+```json
+{
+  "success": true,
+  "message": "",
+  "state": {
+    "gl2_current_id": "1",
+    "gl2_current_name_ru": "Москва"
+  },
+  "confirmed": true
+}
+```
+
+Полный набор ключей в `state` зависит от сервиса и сессии.
+
+### `action=data`
+
+HTML-фрагмент `gl_data` для текущего или указанного города (тот же чанк, что у сниппета).
+
+| Параметр | Описание |
+|----------|----------|
+| `tpl` | Чанк, по умолчанию `tpl.GeoLocation2.data.current` |
+| `city_id` | ID города; если не передан, берётся из сессии |
+
+Пример ответа:
+
+```json
+{
+  "success": true,
+  "html": "<div class=\"gl2-data-current\">...</div>",
+  "city_id": 8,
+  "tpl": "tpl.GeoLocation2.data.current"
+}
+```
+
+### `action=search`
+
+Поиск активных городов для модалки.
+
+| Параметр | Описание |
+|----------|----------|
+| `query` | Подстрока в `name_ru` или `name_en` (может быть пустой) |
+| `limit` | 1–100, по умолчанию 20 |
+
+Пример ответа:
+
+```json
+{
+  "success": true,
+  "items": [{ "id": 1, "name_ru": "Москва", "name_en": "Moscow" }],
+  "query": "моск",
+  "count": 1
+}
+```
+
+## POST
+
+Тело: `application/x-www-form-urlencoded` или `multipart/form-data`.
+
+| Поле | Описание |
+|------|----------|
+| `action` | `save`, `confirm` или `dismiss` |
+| `csrf` | Токен |
+| `city_id` | ID города (`GlCity`) для `save` |
+| `use_default` | `1` — подставить город с флагом `default` |
+
+### `action=save`
+
+Сохраняет `city_id`, выставляет `confirmed=1`.
+
+### `action=confirm`
+
+Подтверждает текущий или переданный город. С `use_default=1` — город по умолчанию из БД.
+
+### `action=dismiss`
+
+Закрытие модалки. С `use_default=1` — записать город по умолчанию и `confirmed=1`. Иначе только `confirmed=1` без смены города (см. `dismissSetsDefault` у [GeoLocation2Modal](snippets/GeoLocation2Modal)).
+
+## Ошибки
+
+```json
+{ "success": false, "message": "..." }
+```
+
+Типичные причины: неверный CSRF, неизвестный `city_id`, неизвестный `action`, запрос без `X-Requested-With`.
+
+## Примеры fetch
+
+Поиск:
+
+```javascript
+fetch('/assets/components/geolocation2/action.php?action=search&query=каз', {
+  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+}).then((r) => r.json());
+```
+
+Сохранение города:
+
+```javascript
+const body = new URLSearchParams({
+  action: 'save',
+  csrf: document.querySelector('[data-gl2-csrf]').dataset.gl2Csrf,
+  city_id: '8',
+});
+fetch('/assets/components/geolocation2/action.php', {
+  method: 'POST',
+  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  body,
+});
+```
+
+JS модалки в `assets/components/geolocation2/js/web/modal.js` вызывает те же actions.
+
+См. [FAQ](faq).

--- a/docs/components/geolocation2/faq.md
+++ b/docs/components/geolocation2/faq.md
@@ -1,0 +1,53 @@
+---
+title: FAQ
+description: Типовые проблемы GeoLocation2 — SxGeo, модалка, CSRF, справочник
+---
+
+# FAQ
+
+## Модалка не открывается
+
+- Вызван ли `[[!GeoLocation2Initialize]]` на странице?
+- Подключён ли Bootstrap 5 (своим шаблоном или через `loadBootstrap=1` у Initialize)?
+- В чанке текущего города есть атрибут `data-gl2-open="1"`?
+
+## SxGeo определяет не тот город
+
+- Обновите `SxGeoCity.dat` — [CLI или Scheduler](integration#obnovlenie-sxgeo).
+- Проверьте названия в `gl_cities`: сопоставление идёт со справочником, не с произвольным текстом.
+- На локальном `127.0.0.1` SxGeo часто не даёт осмысленный город; тестируйте с реальным IP или задайте город вручную через модалку.
+
+## Файл SxGeo отсутствует
+
+Путь: `assets/components/geolocation2/vendor/sypexgeo/data/SxGeoCity.dat`.
+
+Запустите:
+
+```bash
+php assets/components/geolocation2/bin/update-sxgeo.php
+```
+
+или переустановите assets пакета.
+
+## POST action.php возвращает ошибку CSRF
+
+- Сессия PHP должна работать на фронте (cookie, один домен).
+- Берите актуальный `csrf` из `action=state` после перезагрузки страницы.
+- Не кешируйте страницу с формой модалки через полный page cache без исключения для сессии.
+
+## Пустой список городов в модалке
+
+- Заполните `gl_cities` в менеджере или импортируйте CSV.
+- Для `action=search` проверьте параметр `query` и активность записей в БД.
+
+## Package provider not found
+
+Пакет с modstore: в **Установщике** добавьте провайдер `modstore.pro` → `https://modstore.pro/extras/`.
+
+## geolocation2_debug
+
+Поставьте `geolocation2_debug = 1`, воспроизведите проблему, смотрите **Управление → Журнал ошибок**. На проде верните `0`.
+
+## Права в менеджере
+
+Редактирование справочника требует права `geolocation2_save` для политики пользователя.

--- a/docs/components/geolocation2/index.md
+++ b/docs/components/geolocation2/index.md
@@ -1,0 +1,70 @@
+---
+title: GeoLocation2
+description: Геоданные MODX — справочник gl_*, SxGeo, модалка выбора города, REST action.php
+author: Ibochkarev
+repository: https://github.com/Ibochkarev/GeoLocation2
+logo: https://modstore.pro/assets/extras/geolocation2/logo.png
+modstore: https://modstore.pro/packages/utilities/geolocation2
+categories: utilities
+items: [
+  { text: 'Быстрый старт', link: 'quick-start' },
+  { text: 'Системные настройки', link: 'settings' },
+  { text: 'Интеграция', link: 'integration' },
+  { text: 'Web API (action.php)', link: 'api-action' },
+  {
+    text: 'Сниппеты',
+    link: 'snippets',
+    items: [
+      { text: 'GeoLocation2Initialize', link: 'snippets/GeoLocation2Initialize' },
+      { text: 'GeoLocation2Current', link: 'snippets/GeoLocation2Current' },
+      { text: 'GeoLocation2Modal', link: 'snippets/GeoLocation2Modal' },
+      { text: 'GeoLocation2', link: 'snippets/GeoLocation2' },
+      { text: 'GeoLocation2Location', link: 'snippets/GeoLocation2Location' },
+      { text: 'GeoLocation2Data', link: 'snippets/GeoLocation2Data' },
+    ],
+  },
+  { text: 'FAQ', link: 'faq' },
+]
+---
+
+# GeoLocation2
+
+Справочник стран, регионов и городов в таблицах `gl_*`, определение локации по IP через SxGeo, выбор города на фронте (модалка Bootstrap 5) и REST-эндпоинт `action.php`.
+
+## Возможности
+
+- Таблицы `gl_countries`, `gl_regions`, `gl_cities`, `gl_data` и менеджер в админке MODX
+- SxGeo (локальная база `.dat`, без внешних API на каждый запрос)
+- Сессия `$_SESSION['gl2']`: выбранный город, флаг подтверждения, CSRF-токен
+- Сниппеты для списка городов, SxGeo-lookup, `gl_data`, модалки
+- CSV-импорт и экспорт справочников из менеджера
+- Задача Scheduler для автообновления SxGeo (опционально)
+
+## Системные требования
+
+| Требование | Версия |
+|------------|--------|
+| MODX Revolution | 3.0+ |
+| PHP | 8.2+ |
+
+## Установка
+
+1. [Подключите репозиторий ModStore](https://modstore.pro/info/connection).
+2. **Extras → Installer** → **Download Extras** — **GeoLocation2** → **Download** → **Install**.
+3. **Настройки → Очистить кэш**.
+4. Откройте **Компоненты → GeoLocation2** и проверьте вкладки справочника.
+5. Убедитесь, что файл SxGeo на месте: `assets/components/geolocation2/vendor/sypexgeo/data/SxGeoCity.dat`.
+6. Подключите сниппеты на сайте — см. [Быстрый старт](quick-start).
+
+Пакет в каталоге [modstore.pro](https://modstore.pro/packages/utilities/geolocation2). Исходники: [GitHub](https://github.com/Ibochkarev/GeoLocation2).
+
+## Быстрые ссылки
+
+| Раздел | Описание |
+|--------|----------|
+| [Быстрый старт](quick-start) | Минимальная выкладка на сайт |
+| [Системные настройки](settings) | Ключи `geolocation2_*` |
+| [Интеграция](integration) | Менеджер, модель данных, CSV, PHP-сервис, SxGeo |
+| [Web API](api-action) | GET/POST `action.php` |
+| [Сниппеты](snippets/) | Параметры и чанки |
+| [FAQ](faq) | Типовые ошибки |

--- a/docs/components/geolocation2/integration.md
+++ b/docs/components/geolocation2/integration.md
@@ -1,0 +1,112 @@
+---
+title: Интеграция
+description: Менеджер gl_*, модель данных, CSV, PHP-сервис GeoLocation2, обновление SxGeo
+---
+
+# Интеграция
+
+## Менеджер в админке
+
+**Компоненты → GeoLocation2** — вкладки:
+
+| Вкладка | Таблица | Содержимое |
+|---------|---------|------------|
+| Страны | `gl_countries` | ISO, timezone, страна по умолчанию |
+| Регионы | `gl_regions` | Регион, привязка к стране |
+| Города | `gl_cities` | Город, регион, координаты, признак «основной» |
+| Данные | `gl_data` | Контакты, адрес, изображение, alt-название для города |
+
+Импорт и экспорт CSV доступны из интерфейса менеджера (страны, регионы, города).
+
+## Модель данных
+
+```
+gl_countries
+  └── gl_regions
+        └── gl_cities
+              └── gl_data (0..n записей на город)
+```
+
+Сессия пользователя (`$_SESSION['gl2']`, ключ задаётся сервисом):
+
+| Поле сессии | Назначение |
+|-------------|------------|
+| `city_id` | ID из `gl_cities` |
+| `confirmed` | Пользователь подтвердил или выбрал город |
+| `dismissed` | Модалку закрыли без выбора (если применимо) |
+| `csrf` | Токен для POST в `action.php` |
+
+## PHP-сервис
+
+```php
+/** @var \GeoLocation2\Service\GeoLocation2 $gl2 */
+$gl2 = $modx->services->get('GeoLocation2');
+
+$cityId = $gl2->getCurrentCityId();
+$state = $gl2->getSessionState();
+$gl2->setCity($cityId, true);
+```
+
+Методы и события смотрите в исходниках `core/components/geolocation2/src/Service/`.
+
+## SxGeo
+
+Файл базы:
+
+```text
+assets/components/geolocation2/vendor/sypexgeo/data/SxGeoCity.dat
+```
+
+При `geolocation2_detect_method = sxgeo` первый визит без сессии: IP → SxGeo → сопоставление с `gl_cities` (по названию/региону, логика в сервисе).
+
+### Обновление SxGeo
+
+**CLI** (из корня MODX):
+
+```bash
+php assets/components/geolocation2/bin/update-sxgeo.php
+```
+
+**Scheduler** (MODX 3): задача `geolocation2_update_sxgeo`. Включите `geolocation2_sxgeo_auto_update` и задайте `geolocation2_sxgeo_update_interval_days`.
+
+После обновления перезапуск PHP-FPM не обязателен: подхватывается новый `.dat` при следующем обращении к SxGeo.
+
+## Fenom и плейсхолдеры
+
+Текущий город в шаблоне:
+
+::: code-group
+
+```fenom
+{$_modx->runSnippet('!GeoLocation2Current', ['tpl' => 'tpl.GeoLocation2.current'])}
+```
+
+```modx
+[[!GeoLocation2Current? &tpl=`tpl.GeoLocation2.current`]]
+```
+
+:::
+
+Плейсхолдеры чанка зависят от `tpl`; в `tpl.GeoLocation2.current` обычно есть `[[+city_name]]`, `[[+region_name]]`, `[[+country_name]]`.
+
+## Связь с miniShop и доставкой
+
+GeoLocation2 не меняет корзину сам. Типичная схема:
+
+1. Пользователь выбирает город в модалке.
+2. `city_id` из сессии передаёте в сниппет доставки или в options заказа.
+3. `gl_data` используйте для телефона/адреса пункта выдачи в выбранном городе.
+
+## Чанки пакета
+
+| Чанк | Назначение |
+|------|------------|
+| `tpl.GeoLocation2.current` | Текущий город (кнопка открытия модалки) |
+| `tpl.GeoLocation2.modal` | Разметка модалки Bootstrap 5 |
+| `tpl.GeoLocation2.modal.item` | Строка города в списке модалки |
+| `tpl.GeoLocation2.item` | Строка в списке `GeoLocation2` |
+| `tpl.GeoLocation2.location` | Вывод SxGeo lookup |
+| `tpl.GeoLocation2.data.item` | Строка таблицы `gl_data` |
+| `tpl.GeoLocation2.data.current` | Карточка `gl_data` для текущего города |
+
+См. [Web API](api-action) и [сниппеты](snippets/).

--- a/docs/components/geolocation2/quick-start.md
+++ b/docs/components/geolocation2/quick-start.md
@@ -1,0 +1,85 @@
+---
+title: Быстрый старт
+description: Минимальная настройка GeoLocation2 на сайте — инициализация, модалка, текущий город
+---
+
+# Быстрый старт
+
+## 1. Настройки
+
+В **Система → Настройки системы → geolocation2** задайте:
+
+| Ключ | Рекомендация для старта |
+|------|-------------------------|
+| `geolocation2_detect_method` | `sxgeo` — определение по IP при первом визите |
+| `geolocation2_debug` | `0` на проде, `1` при отладке |
+
+Подробнее: [Системные настройки](settings).
+
+## 2. Шаблон сайта
+
+В `<head>` или перед `</body>` подключите инициализацию (CSS/JS и Bootstrap 5, если ещё нет на странице):
+
+::: code-group
+
+```fenom
+{'!GeoLocation2Initialize' | snippet}
+```
+
+```modx
+[[!GeoLocation2Initialize]]
+```
+
+:::
+
+Параметры `loadBootstrap`, `loadCss`, `loadJs` — в [GeoLocation2Initialize](snippets/GeoLocation2Initialize).
+
+## 3. Модалка и текущий город
+
+В шапке или футере:
+
+::: code-group
+
+```fenom
+{'!GeoLocation2Current' | snippet : [
+  'tpl' => 'tpl.GeoLocation2.current'
+]}
+{'!GeoLocation2Modal' | snippet}
+```
+
+```modx
+[[!GeoLocation2Current? &tpl=`tpl.GeoLocation2.current`]]
+[[!GeoLocation2Modal]]
+```
+
+:::
+
+Чанк `tpl.GeoLocation2.current` поставляется с пакетом. В нём кнопка с `data-gl2-open="1"` открывает модалку.
+
+## 4. Проверка
+
+1. Откройте сайт в режиме инкогнито.
+2. Должна появиться модалка с предложением города (SxGeo) или списком городов.
+3. После выбора город сохраняется в `$_SESSION['gl2']`.
+4. Запрос `GET /assets/components/geolocation2/action.php?action=state` (с заголовком `X-Requested-With`) возвращает JSON с `state`, `confirmed` и полями сессии.
+
+## 5. Данные по городу
+
+Если заполнили `gl_data` в менеджере:
+
+::: code-group
+
+```fenom
+{'!GeoLocation2Data' | snippet : [
+  'forCurrent' => 1,
+  'tpl' => 'tpl.GeoLocation2.data.current'
+]}
+```
+
+```modx
+[[!GeoLocation2Data? &forCurrent=`1` &tpl=`tpl.GeoLocation2.data.current`]]
+```
+
+:::
+
+Дальше: [Интеграция](integration), [Web API](api-action), [FAQ](faq).

--- a/docs/components/geolocation2/settings.md
+++ b/docs/components/geolocation2/settings.md
@@ -1,0 +1,38 @@
+---
+title: Системные настройки
+description: Ключи namespace geolocation2 в MODX
+---
+
+# Системные настройки
+
+Namespace: **geolocation2**. В БД ключи с префиксом `geolocation2_`.
+
+## Основные
+
+| Ключ | Тип | По умолчанию | Описание |
+|------|-----|--------------|----------|
+| `geolocation2_debug` | boolean | `0` | Логирование в MODX error log |
+| `geolocation2_detect_method` | text | `sxgeo` | Первичное определение: `sxgeo` (IP → SxGeo) или `session` (только сохранённая сессия) |
+
+## SxGeo
+
+| Ключ | Тип | По умолчанию | Описание |
+|------|-----|--------------|----------|
+| `geolocation2_sxgeo_auto_update` | boolean | `1` | Автообновление базы через Scheduler |
+| `geolocation2_sxgeo_update_interval_days` | number | `14` | Интервал между проверками обновления (дней) |
+| `geolocation2_sxgeo_last_run_at` | text | *(пусто)* | Служебное: время последнего запуска задачи |
+| `geolocation2_sxgeo_last_status` | text | *(пусто)* | Служебное: статус последнего обновления |
+| `geolocation2_sxgeo_last_message` | text | *(пусто)* | Служебное: сообщение последнего обновления |
+| `geolocation2_sxgeo_last_header_time` | text | *(пусто)* | Служебное: дата из заголовка скачанного файла |
+
+Ключи `geolocation2_sxgeo_last_*` пишет компонент при автоматическом обновлении и CLI. Вручную их обычно не меняют.
+
+## Права доступа
+
+| Идентификатор | Назначение |
+|---------------|------------|
+| `geolocation2_save` | Сохранение записей в менеджере GeoLocation2 |
+
+Обновление SxGeo вручную и через Scheduler не требует отдельного права на фронте: достаточно доступа к файловой системе или задаче планировщика.
+
+См. также: [Интеграция → обновление SxGeo](integration#obnovlenie-sxgeo).

--- a/docs/components/geolocation2/snippets/GeoLocation2.md
+++ b/docs/components/geolocation2/snippets/GeoLocation2.md
@@ -1,0 +1,82 @@
+---
+title: GeoLocation2
+description: Список активных городов из gl_cities
+---
+
+# GeoLocation2
+
+Выводит список **активных** городов из `gl_cities`. Каждая строка — один проход чанка `tpl`. Сессию и модалку не трогает: статический справочник для меню, карты сайта или подсказок в шаблоне.
+
+## Параметры
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `tpl` | `tpl.GeoLocation2.item` | Чанк одной строки |
+| `sortby` | `name_ru` | Поле сортировки (`name_ru`, `name_en`, `id`, …) |
+| `sortdir` | `ASC` | `ASC` или `DESC` |
+| `limit` | `10` | Максимум строк; `0` — все активные |
+| `region_id` | *(пусто)* | Фильтр по `gl_regions.id` |
+| `outputSeparator` | перевод строки | Между строками |
+| `toPlaceholder` | *(пусто)* | Имя плейсхолдера вместо вывода |
+
+## Вызов
+
+::: code-group
+
+```modx
+[[!GeoLocation2]]
+[[!GeoLocation2? &limit=`0` &sortby=`name_ru`]]
+[[!GeoLocation2? &region_id=`5` &limit=`20`]]
+```
+
+```fenom
+{'!GeoLocation2' | snippet}
+{'!GeoLocation2' | snippet : ['limit' => 0, 'region_id' => 5]}
+```
+
+:::
+
+## Пример вывода
+
+Чанк по умолчанию `tpl.GeoLocation2.item` для двух городов:
+
+```html
+<p>
+    <strong>Москва</strong>
+    Moscow — id региона: 1
+    55.7558 37.6173
+</p>
+<p>
+    <strong>Казань</strong>
+    Kazan — id региона: 2
+    55.7963 49.1088
+</p>
+```
+
+Плейсхолдеры строки — поля `GlCity`: `id`, `name_ru`, `name_en`, `region_id`, `lat`, `lon`, `active`, `default` и др.
+
+## Свой чанк — ссылки на город
+
+::: code-group
+
+```modx
+<a href="[[~42]]?city=[[+id]]">[[+name_ru]]</a>
+```
+
+```fenom
+<a href="{$_modx->makeUrl(42)}?city={$id}">{$name_ru}</a>
+```
+
+:::
+
+Логику «выбрать город по клику» лучше вешать на [GeoLocation2Modal](GeoLocation2Modal) или свой JS с `action=save`.
+
+## Отличие от модалки
+
+| | GeoLocation2 | GeoLocation2Modal |
+|---|--------------|-------------------|
+| Источник | Только `gl_cities` | Сессия + SxGeo + API search |
+| Кеш страницы | Можно кешировать список отдельно | Modal/Initialize — некэшированно |
+| Выбор города | Нет | Да |
+
+См. [GeoLocation2Modal](GeoLocation2Modal).

--- a/docs/components/geolocation2/snippets/GeoLocation2Current.md
+++ b/docs/components/geolocation2/snippets/GeoLocation2Current.md
@@ -1,0 +1,98 @@
+---
+title: GeoLocation2Current
+description: Текущий город из сессии GeoLocation2 — чанк или JSON
+---
+
+# GeoLocation2Current
+
+Показывает город, который компонент считает текущим: из сессии, из SxGeo (если сессии ещё нет) или город по умолчанию из `gl_cities`. Данные берёт из `buildWebPlaceholders()` сервиса GeoLocation2.
+
+## Параметры
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `tpl` | `tpl.GeoLocation2.current` | Чанк HTML |
+| `asJson` | `0` | Вернуть JSON плейсхолдеров `gl2_*` вместо чанка |
+| `toPlaceholder` | `0` | Записать вывод в плейсхолдер |
+
+## Вызов
+
+::: code-group
+
+```modx
+[[!GeoLocation2Current]]
+[[!GeoLocation2Current? &tpl=`tpl.GeoLocation2.current`]]
+[[!GeoLocation2Current? &asJson=`1`]]
+```
+
+```fenom
+{'!GeoLocation2Current' | snippet}
+{'!GeoLocation2Current' | snippet : ['asJson' => 1]}
+```
+
+:::
+
+## Плейсхолдеры `gl2_*`
+
+Доступны в чанке и в JSON при `asJson=1`:
+
+| Плейсхолдер | Смысл |
+|-------------|--------|
+| `gl2_current_id` | ID города в `gl_cities` |
+| `gl2_current_name_ru` | Название (RU) |
+| `gl2_current_name_en` | Название (EN) |
+| `gl2_display_name_ru` | Имя в тексте модалки (может подставить SxGeo) |
+| `gl2_real_name_ru` | Город из SxGeo |
+| `gl2_default_id` / `gl2_default_name_ru` | Город с флагом default |
+| `gl2_confirmed` / `gl2_prompt_done` | `1`, если пользователь подтвердил выбор |
+| `gl2_csrf` | Токен для POST в `action.php` |
+
+## Пример вывода (чанк по умолчанию)
+
+Чанк `tpl.GeoLocation2.current`:
+
+```html
+<span class="gl2-current-city" data-city-id="1" data-confirmed="0">Москва</span>
+```
+
+`data-confirmed="0"` до первого подтверждения в модалке, `"1"` после.
+
+Свой чанк — кнопка с `data-gl2-open="1"`, чтобы открыть [GeoLocation2Modal](GeoLocation2Modal):
+
+::: code-group
+
+```modx
+<button type="button" class="btn btn-link" data-gl2-open="1">[[+gl2_current_name_ru]]</button>
+```
+
+```fenom
+<button type="button" class="btn btn-link" data-gl2-open="1">{$gl2_current_name_ru}</button>
+```
+
+:::
+
+## Пример JSON (`asJson=1`)
+
+```json
+{
+  "gl2_current_id": "1",
+  "gl2_current_name_ru": "Москва",
+  "gl2_current_name_en": "Moscow",
+  "gl2_display_name_ru": "Москва",
+  "gl2_real_name_ru": "Москва",
+  "gl2_confirmed": "0",
+  "gl2_csrf": "a1b2c3…"
+}
+```
+
+Удобно для SPA или своего JS без разметки модалки.
+
+## MODX / Fenom в чанке
+
+| Поле | MODX | Fenom |
+|------|------|-------|
+| ID города | `[[+gl2_current_id]]` | `{$gl2_current_id}` |
+| Название | `[[+gl2_current_name_ru]]` | `{$gl2_current_name_ru}` |
+| Подтверждён | `[[+gl2_confirmed]]` | `{$gl2_confirmed}` |
+
+См. [GeoLocation2Modal](GeoLocation2Modal), [Web API](../api-action).

--- a/docs/components/geolocation2/snippets/GeoLocation2Data.md
+++ b/docs/components/geolocation2/snippets/GeoLocation2Data.md
@@ -1,0 +1,160 @@
+---
+title: GeoLocation2Data
+description: Контакты и адрес из gl_data для города или объекта
+---
+
+# GeoLocation2Data
+
+Выводит строки таблицы `gl_data`: email, телефон, адрес, картинка, alt-имя, JSON в `properties`. Данные задаются во вкладке **Данные** менеджера GeoLocation2.
+
+## Параметры
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `tpl` | `tpl.GeoLocation2.data.item` | Чанк одной записи |
+| `sortby` | `id` | `id`, `class`, `identifier`, `name_alt`, `resource`, `email`, `default` |
+| `sortdir` | `DESC` | `ASC` / `DESC` |
+| `limit` | `0` | Лимит; `0` — без лимита |
+| `class` | *(пусто)* | `GlCountry`, `GlRegion`, `GlCity` |
+| `identifier` | *(пусто)* | ID объекта в таблице класса |
+| `onlyDefault` | `0` | Только `default=1` |
+| `forCurrent` | `0` | Записи для текущего города из сессии |
+| `liveUpdate` | как `forCurrent` | Обёртка `[data-gl2-data-live]` + обновление через API |
+| `outputSeparator` | перевод строки | Между строками |
+| `toPlaceholder` | *(пусто)* | Плейсхолдер вместо вывода |
+
+## Режимы
+
+### Все записи (как в менеджере)
+
+::: code-group
+
+```modx
+[[!GeoLocation2Data? &limit=`0` &sortby=`id` &sortdir=`DESC`]]
+```
+
+```fenom
+{'!GeoLocation2Data' | snippet : ['limit' => 0]}
+```
+
+:::
+
+Вывод — строки `<tr>` чанка `tpl.GeoLocation2.data.item` (удобно внутри `<table>`).
+
+### Текущий город (`forCurrent=1`)
+
+Берёт `gl2_current_id` из той же сессии, что [GeoLocation2Modal](GeoLocation2Modal).
+
+::: code-group
+
+```modx
+[[!GeoLocation2Data? &forCurrent=`1` &tpl=`tpl.GeoLocation2.data.current`]]
+```
+
+```fenom
+{'!GeoLocation2Data' | snippet : [
+  'forCurrent' => 1,
+  'tpl' => 'tpl.GeoLocation2.data.current'
+]}
+```
+
+:::
+
+### Фильтр по городу
+
+Контакты только для Москвы (`GlCity`, id=1):
+
+::: code-group
+
+```modx
+[[!GeoLocation2Data? &class=`GlCity` &identifier=`1`]]
+```
+
+```fenom
+{'!GeoLocation2Data' | snippet : ['class' => 'GlCity', 'identifier' => 1]}
+```
+
+:::
+
+## Пример вывода
+
+**Карточка** `tpl.GeoLocation2.data.current`:
+
+```html
+<div class="gl2-data-current gl2-qa-box" data-gl2-data-id="3">
+  <dl class="gl2-qa-kv">
+    <dt>Класс / ID локации</dt>
+    <dd>GlCity · 1 (Москва, офис)</dd>
+    <dt>Email / телефон</dt>
+    <dd>info@example.ru · +7 (495) 000-00-00</dd>
+    <dt>Адрес</dt>
+    <dd>ул. Пример, 1</dd>
+    …
+  </dl>
+</div>
+```
+
+**Строка таблицы** `tpl.GeoLocation2.data.item`:
+
+```html
+<tr class="gl2-data-row" data-gl2-data-id="3" data-gl2-data-class="GlCity" data-gl2-data-identifier="1">
+  <td>3</td>
+  <td>GlCity</td>
+  <td>1</td>
+  <td>Москва, офис</td>
+  …
+</tr>
+```
+
+Дополнительные плейсхолдеры: `default_label` (`Да`/`Нет`), `default_pill_class`, `image_display`, `properties_json`.
+
+## Live-обновление
+
+При `forCurrent=1` по умолчанию `liveUpdate=1`. Блок оборачивается:
+
+```html
+<div data-gl2-data-live data-gl2-data-tpl="tpl.GeoLocation2.data.current">
+  … HTML карточки …
+</div>
+```
+
+После смены города в модалке `modal.js` вызывает `GET action=data` и подменяет innerHTML без перезагрузки.
+
+Отключить:
+
+::: code-group
+
+```modx
+[[!GeoLocation2Data? &forCurrent=`1` &liveUpdate=`0`]]
+```
+
+```fenom
+{'!GeoLocation2Data' | snippet : ['forCurrent' => 1, 'liveUpdate' => 0]}
+```
+
+:::
+
+## Типовая вёрстка
+
+::: code-group
+
+```modx
+<table class="table">
+  <thead><tr><th>ID</th><th>Email</th><th>Телефон</th></tr></thead>
+  <tbody>
+    [[!GeoLocation2Data? &class=`GlCity` &identifier=`[[+city_id]]`]]
+  </tbody>
+</table>
+```
+
+```fenom
+<table class="table">
+  <tbody>
+    {'!GeoLocation2Data' | snippet : ['forCurrent' => 1]}
+  </tbody>
+</table>
+```
+
+:::
+
+См. [Web API → action=data](../api-action), [GeoLocation2Modal](GeoLocation2Modal).

--- a/docs/components/geolocation2/snippets/GeoLocation2Initialize.md
+++ b/docs/components/geolocation2/snippets/GeoLocation2Initialize.md
@@ -1,0 +1,66 @@
+---
+title: GeoLocation2Initialize
+description: Подключение CSS/JS модалки GeoLocation2 и конфиг action.php
+---
+
+# GeoLocation2Initialize
+
+Подключает ассеты модалки и задаёт глобальный конфиг для `modal.js`. Сам по себе на странице ничего не показывает: в HTML попадают только `<link>`, `<script>` и объект `window.GeoLocation2Web`.
+
+Вызывайте **один раз** на странице, где есть [GeoLocation2Modal](GeoLocation2Modal) или блоки с `data-gl2-data-live`.
+
+## Параметры
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `loadBootstrap` | `0` | Bootstrap 5.3 с jsDelivr (CSS + bundle JS) |
+| `loadCss` | `1` | `assets/.../css/web/modal.css` |
+| `loadJs` | `1` | `assets/.../js/web/modal.js` (defer) |
+| `toPlaceholder` | `0` | Записать вывод в плейсхолдер вместо echo |
+
+Если Bootstrap 5 уже в теме, оставьте `loadBootstrap=0`.
+
+## Вызов
+
+::: code-group
+
+```modx
+[[!GeoLocation2Initialize]]
+[[!GeoLocation2Initialize? &loadBootstrap=`1`]]
+```
+
+```fenom
+{'!GeoLocation2Initialize' | snippet}
+{'!GeoLocation2Initialize' | snippet : ['loadBootstrap' => 1, 'loadCss' => 1, 'loadJs' => 1]}
+```
+
+:::
+
+## Что попадает в HTML
+
+Фрагмент (упрощённо):
+
+```html
+<link rel="stylesheet" href="/assets/components/geolocation2/css/web/modal.css?v=…">
+<script>window.GeoLocation2Web = Object.assign({}, window.GeoLocation2Web || {}, {"actionUrl":"/assets/components/geolocation2/action.php","messages":{"networkError":"…"}});</script>
+<script src="/assets/components/geolocation2/js/web/modal.js?v=…" defer></script>
+```
+
+С `loadBootstrap=1` добавляются CDN-ссылки Bootstrap 5.3.3.
+
+`actionUrl` и текст сетевой ошибки читает `modal.js` при POST на `action.php`.
+
+## Связь с другими сниппетами
+
+| Сниппет | Зависимость |
+|---------|-------------|
+| GeoLocation2Modal | Нужны CSS/JS; без Initialize используйте `includeAssets=1` у модалки (legacy) |
+| GeoLocation2Data + `liveUpdate` | `modal.js` после смены города дергает `action=data` |
+| GeoLocation2Current | Не зависит от Initialize |
+
+## Типичные ошибки
+
+- Модалка не открывается: нет Initialize и `includeAssets=0` у Modal.
+- Дубли Bootstrap: и тема, и `loadBootstrap=1` — конфликт стилей.
+
+См. [GeoLocation2Modal](GeoLocation2Modal), [FAQ](../faq).

--- a/docs/components/geolocation2/snippets/GeoLocation2Location.md
+++ b/docs/components/geolocation2/snippets/GeoLocation2Location.md
@@ -1,0 +1,107 @@
+---
+title: GeoLocation2Location
+description: Геолокация посетителя по IP через SxGeo
+---
+
+# GeoLocation2Location
+
+Берёт IP посетителя (или параметр `ip`), читает локальную базу SxGeo и рендерит чанк с плоскими плейсхолдерами `city_*`, `region_*`, `country_*`. Справочник `gl_cities` и сессию не меняет.
+
+Полезно для отладки SxGeo, блока «мы определили ваш регион» без модалки или A/B-теста до внедрения [GeoLocation2Modal](GeoLocation2Modal).
+
+## Параметры
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `tpl` | `tpl.GeoLocation2.location` | Чанк вывода |
+| `ip` | IP посетителя | Явный IP (тест с `8.8.8.8`) |
+| `toPlaceholder` | *(пусто)* | Плейсхолдер вместо echo |
+
+## Вызов
+
+::: code-group
+
+```modx
+[[!GeoLocation2Location]]
+[[!GeoLocation2Location? &ip=`8.8.8.8`]]
+```
+
+```fenom
+{'!GeoLocation2Location' | snippet}
+{'!GeoLocation2Location' | snippet : ['ip' => '8.8.8.8']}
+```
+
+:::
+
+## Как формируются плейсхолдеры
+
+1. `getCityFullByIp()` → вложенный массив SxGeo.
+2. Массив «сплющивается» в ключи вида `city_name_ru`, `region_name_ru`.
+3. `processData()` добавляет HTML-обёртки: `city_name_ru_html`, `country_iso_html` и т.д.
+
+Набор ключей зависит от редакции `SxGeoCity.dat`. Типичные:
+
+| Плейсхолдер | Пример |
+|-------------|--------|
+| `city_name_ru` | Москва |
+| `region_name_ru` | Москва |
+| `country_name_ru` | Россия |
+| `country_iso` | RU |
+| `city_name_ru_html` | `<span>Москва</span>` (после processData) |
+
+При `geolocation2_debug=1` смотрите сырой ответ в журнале, если чанк пустой.
+
+## Пример вывода
+
+Чанк `tpl.GeoLocation2.location`:
+
+```html
+<div class="geolocation2-location">
+    <span>Москва</span>
+    <span>Moscow</span>
+    <span>Москва</span>
+    <span>Россия</span>
+    <span>RU</span>
+</div>
+```
+
+## Пустой результат
+
+Сниппет вернёт пустую строку, если:
+
+- нет файла `SxGeoCity.dat`;
+- IP не найден (часто `127.0.0.1` на localhost);
+- сервис GeoLocation2 не зарегистрирован.
+
+Добавьте fallback в чанк:
+
+::: code-group
+
+```modx
+[[!GeoLocation2Location:notempty=`
+  <p>Ваш регион: [[+city_name_ru]]</p>
+`:default=`
+  <p>Регион не определился</p>
+`]]
+```
+
+```fenom
+{$geo = '!GeoLocation2Location' | snippet}
+{if $geo}
+  <div class="geolocation2-location-fallback">{$geo}</div>
+{else}
+  <p>Регион не определился</p>
+{/if}
+```
+
+:::
+
+## SxGeo vs модалка
+
+| | GeoLocation2Location | GeoLocation2Modal |
+|---|----------------------|-------------------|
+| Данные | Только SxGeo | SxGeo + `gl_cities` + сессия |
+| Сохранение выбора | Нет | Да |
+| Сопоставление с справочником | Нет | `findGlCityFromSxGeo()` |
+
+См. [Интеграция → SxGeo](../integration), [FAQ](../faq).

--- a/docs/components/geolocation2/snippets/GeoLocation2Modal.md
+++ b/docs/components/geolocation2/snippets/GeoLocation2Modal.md
@@ -1,0 +1,104 @@
+---
+title: GeoLocation2Modal
+description: Модалка подтверждения и смены города Bootstrap 5
+---
+
+# GeoLocation2Modal
+
+Рисует модальное окно Bootstrap 5 и строку «Ваш город» под ним. Работает с сессией, CSRF и [action.php](../api-action). На странице также выставляет плейсхолдеры `gl2_*` (их видят [GeoLocation2Current](GeoLocation2Current) и Fenom).
+
+Перед модалкой подключите [GeoLocation2Initialize](GeoLocation2Initialize) или передайте `includeAssets=1` (старый вариант, всё в одном сниппете).
+
+## Параметры
+
+| Параметр | По умолчанию | Описание |
+|----------|--------------|----------|
+| `tpl` | `tpl.GeoLocation2.modal` | Чанк модалки + тулбар |
+| `itemTpl` | `tpl.GeoLocation2.modal.item` | Строка города в списке |
+| `modalShow` | `1` | Автопоказ при первом визите (`data-gl2-modal-show`) |
+| `includeAssets` | `0` | Встроить CSS/JS в вывод этого сниппета |
+| `loadBootstrap` | `0` | Bootstrap 5 CDN (с `includeAssets=1`) |
+| `preferRealWhenDefault` | `1` | В вопросе показать имя из SxGeo, если сейчас город по умолчанию |
+| `dismissSetsDefault` | `1` | Закрытие крестиком → город default (`data-gl2-dismiss-default`) |
+| `modalId` | `geolocation2Modal` | HTML `id` модалки |
+| `unknownCityLabel` | лексикон | Подпись, если город не определён |
+| `defaultCityLabel` | лексикон | Подпись города по умолчанию |
+| `toPlaceholder` | `0` | Вывод в плейсхолдер |
+
+## Вызов
+
+::: code-group
+
+```modx
+[[!GeoLocation2Initialize]]
+[[!GeoLocation2Modal? &modalShow=`1`]]
+[[!GeoLocation2Current]]
+```
+
+```fenom
+{'!GeoLocation2Initialize' | snippet : ['loadBootstrap' => 0]}
+{'!GeoLocation2Modal' | snippet : ['modalShow' => 1, 'dismissSetsDefault' => 1]}
+{'!GeoLocation2Current' | snippet}
+```
+
+:::
+
+## Что делает на странице
+
+1. **Шаг confirm** — «Ваш город — **Москва**?» Кнопки «Да» (`action=confirm`) и «Изменить» (переход к списку).
+2. **Шаг list** — поле поиска и список городов. Поиск и подгрузка идут через `action=search`, чтобы работало на закэшированных страницах. В HTML при первом рендере список тоже заполняется из БД (fallback без JS).
+3. **Тулбар** под модалкой — текущий город и ссылка `.gl2-open-modal` для повторного открытия.
+
+При `modalShow=1` и `gl2_confirmed=0` скрипт открывает модалку после загрузки.
+
+## Фрагмент разметки
+
+Упрощённо, из `tpl.GeoLocation2.modal`:
+
+```html
+<div class="modal fade geolocation2-modal" id="geolocation2Modal"
+    data-gl2-root
+    data-gl2-action-url="/assets/components/geolocation2/action.php"
+    data-gl2-csrf="…"
+    data-gl2-modal-show="1"
+    …>
+  <div class="modal-body">
+    <div id="gl2-step-confirm">
+      <p>… — <strong class="gl2-display-city">Москва</strong>?</p>
+      <button class="btn btn-primary gl2-action-yes">Да</button>
+      <button class="btn btn-outline-secondary gl2-action-change">Изменить</button>
+    </div>
+    <div id="gl2-step-list" class="d-none">…</div>
+  </div>
+</div>
+<p class="geolocation2-toolbar">
+  <strong class="gl2-toolbar-city">Москва</strong>
+  <a href="#" class="gl2-open-modal">Изменить</a>
+</p>
+```
+
+## POST в action.php
+
+| Действие | Когда |
+|----------|--------|
+| `confirm` | «Да» на шаге confirm |
+| `save` | Выбор города из списка |
+| `dismiss` | Закрытие крестиком или backdrop |
+
+В каждом POST нужен `csrf` из `data-gl2-csrf` и заголовок `X-Requested-With: XMLHttpRequest`.
+
+## Чанк строки города
+
+`tpl.GeoLocation2.modal.item`:
+
+```html
+<button type="button" class="list-group-item gl2-pick-city" data-city-id="8">
+  Казань <span class="text-muted">(Kazan)</span>
+</button>
+```
+
+## Legacy: `includeAssets=1`
+
+Подключает CSS/JS прямо из Modal, без Initialize. Для новых сайтов лучше разделить Initialize и Modal.
+
+См. [GeoLocation2Initialize](GeoLocation2Initialize), [GeoLocation2Current](GeoLocation2Current), [FAQ](../faq).

--- a/docs/components/geolocation2/snippets/index.md
+++ b/docs/components/geolocation2/snippets/index.md
@@ -1,0 +1,43 @@
+---
+title: Сниппеты
+description: Обзор сниппетов GeoLocation2
+---
+
+# Сниппеты GeoLocation2
+
+| Сниппет | Назначение |
+|---------|------------|
+| [GeoLocation2Initialize](GeoLocation2Initialize) | CSS/JS модалки и `window.GeoLocation2Web` |
+| [GeoLocation2Current](GeoLocation2Current) | Текущий город в шапке или JSON состояния |
+| [GeoLocation2Modal](GeoLocation2Modal) | Модалка подтверждения и смены города |
+| [GeoLocation2](GeoLocation2) | Список городов из `gl_cities` |
+| [GeoLocation2Location](GeoLocation2Location) | Город/регион/страна по IP через SxGeo |
+| [GeoLocation2Data](GeoLocation2Data) | Контакты и адрес из `gl_data` |
+
+## Порядок на странице
+
+1. [GeoLocation2Initialize](GeoLocation2Initialize) — один раз в шаблоне.
+2. [GeoLocation2Current](GeoLocation2Current) — виджет «Ваш город».
+3. [GeoLocation2Modal](GeoLocation2Modal) — разметка модалки (часто в футере).
+4. [GeoLocation2Data](GeoLocation2Data) с `forCurrent=1`, если нужны контакты выбранного города.
+
+[GeoLocation2](GeoLocation2) и [GeoLocation2Location](GeoLocation2Location) к модалке не привязаны: первый рисует статический список, второй показывает сырые данные SxGeo.
+
+Вызовы на фронте — **некэшированные** (`[[!...]]`, `{'!...' | snippet}`). Иначе CSRF и город из сессии застрянут в кеше страницы.
+
+## MODX / Fenom
+
+| Задача | MODX | Fenom |
+|--------|------|-------|
+| Инициализация | `[[!GeoLocation2Initialize]]` | `{'!GeoLocation2Initialize' \| snippet}` |
+| Текущий город | `[[!GeoLocation2Current]]` | `{'!GeoLocation2Current' \| snippet}` |
+| Модалка | `[[!GeoLocation2Modal]]` | `{'!GeoLocation2Modal' \| snippet}` |
+| Список городов | `[[!GeoLocation2? &limit=`0`]]` | `{'!GeoLocation2' \| snippet : ['limit' => 0]}` |
+| SxGeo | `[[!GeoLocation2Location]]` | `{'!GeoLocation2Location' \| snippet}` |
+| Данные города | `[[!GeoLocation2Data? &forCurrent=`1`]]` | `{'!GeoLocation2Data' \| snippet : ['forCurrent' => 1]}` |
+
+## См. также
+
+- [Web API](../api-action)
+- [Быстрый старт](../quick-start)
+- [Интеграция](../integration)

--- a/docs/en/components/geolocation2/api-action.md
+++ b/docs/en/components/geolocation2/api-action.md
@@ -1,0 +1,146 @@
+---
+title: Web API (action.php)
+description: GeoLocation2 REST endpoint — state, data, search, save, confirm, dismiss
+---
+
+# Web API (action.php)
+
+URL:
+
+```text
+/assets/components/geolocation2/action.php
+```
+
+Response is always JSON. Send requests with header `X-Requested-With: XMLHttpRequest`.
+
+With `geolocation2_debug = 1`, details may appear in the MODX error log.
+
+## CSRF
+
+POST (`save`, `confirm`, `dismiss`) requires `csrf` from placeholder `gl2_csrf` (session). Modal snippet and `action=state` provide the token.
+
+## GET
+
+### `action=state`
+
+Current state without changing the session.
+
+```http
+GET /assets/components/geolocation2/action.php?action=state
+```
+
+Example response:
+
+```json
+{
+  "success": true,
+  "message": "",
+  "state": {
+    "gl2_current_id": "1",
+    "gl2_current_name_ru": "Moscow"
+  },
+  "confirmed": true
+}
+```
+
+Full `state` keys depend on service and session.
+
+### `action=data`
+
+HTML fragment of `gl_data` for current or given city (same chunk as the snippet).
+
+| Parameter | Description |
+|-----------|-------------|
+| `tpl` | Chunk, default `tpl.GeoLocation2.data.current` |
+| `city_id` | City ID; if omitted, taken from session |
+
+Example response:
+
+```json
+{
+  "success": true,
+  "html": "<div class=\"gl2-data-current\">...</div>",
+  "city_id": 8,
+  "tpl": "tpl.GeoLocation2.data.current"
+}
+```
+
+### `action=search`
+
+Search active cities for the modal.
+
+| Parameter | Description |
+|-----------|-------------|
+| `query` | Substring in `name_ru` or `name_en` (may be empty) |
+| `limit` | 1–100, default 20 |
+
+Example response:
+
+```json
+{
+  "success": true,
+  "items": [{ "id": 1, "name_ru": "Moscow", "name_en": "Moscow" }],
+  "query": "mos",
+  "count": 1
+}
+```
+
+## POST
+
+Body: `application/x-www-form-urlencoded` or `multipart/form-data`.
+
+| Field | Description |
+|-------|-------------|
+| `action` | `save`, `confirm` or `dismiss` |
+| `csrf` | Token |
+| `city_id` | City ID (`GlCity`) for `save` |
+| `use_default` | `1` — use city with `default` flag |
+
+### `action=save`
+
+Saves `city_id`, sets `confirmed=1`.
+
+### `action=confirm`
+
+Confirms current or given city. With `use_default=1` — default city from DB.
+
+### `action=dismiss`
+
+Close modal. With `use_default=1` — write default city and `confirmed=1`. Otherwise only `confirmed=1` without changing city (see `dismissSetsDefault` on [GeoLocation2Modal](snippets/GeoLocation2Modal)).
+
+## Errors
+
+```json
+{ "success": false, "message": "..." }
+```
+
+Common causes: invalid CSRF, unknown `city_id`, unknown `action`, missing `X-Requested-With`.
+
+## fetch examples
+
+Search:
+
+```javascript
+fetch('/assets/components/geolocation2/action.php?action=search&query=kaz', {
+  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+}).then((r) => r.json());
+```
+
+Save city:
+
+```javascript
+const body = new URLSearchParams({
+  action: 'save',
+  csrf: document.querySelector('[data-gl2-csrf]').dataset.gl2Csrf,
+  city_id: '8',
+});
+fetch('/assets/components/geolocation2/action.php', {
+  method: 'POST',
+  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  body,
+});
+```
+
+Modal JS in `assets/components/geolocation2/js/web/modal.js` uses the same actions.
+
+See [FAQ](faq).

--- a/docs/en/components/geolocation2/faq.md
+++ b/docs/en/components/geolocation2/faq.md
@@ -1,0 +1,53 @@
+---
+title: FAQ
+description: GeoLocation2 — SxGeo, modal, CSRF, catalog
+---
+
+# FAQ
+
+## Modal does not open
+
+- Is `[[!GeoLocation2Initialize]]` on the page?
+- Is Bootstrap 5 loaded (theme or `loadBootstrap=1` on Initialize)?
+- Does the current-city chunk have `data-gl2-open="1"`?
+
+## SxGeo picks wrong city
+
+- Update `SxGeoCity.dat` — [CLI or Scheduler](integration#sxgeo-update).
+- Check `gl_cities` names: matching uses the catalog, not free text.
+- On local `127.0.0.1` SxGeo often returns nothing useful; test with a real IP or pick a city manually.
+
+## SxGeo file missing
+
+Path: `assets/components/geolocation2/vendor/sypexgeo/data/SxGeoCity.dat`.
+
+Run:
+
+```bash
+php assets/components/geolocation2/bin/update-sxgeo.php
+```
+
+or reinstall package assets.
+
+## POST action.php CSRF error
+
+- PHP session must work on the front (cookie, same domain).
+- Use fresh `csrf` from `action=state` after reload.
+- Do not full-page cache modal markup without excluding session.
+
+## Empty city list in modal
+
+- Fill `gl_cities` in the manager or import CSV.
+- For `action=search` check `query` and active records in DB.
+
+## Package provider not found
+
+modstore package: in **Installer** add provider `modstore.pro` → `https://modstore.pro/extras/`.
+
+## geolocation2_debug
+
+Set `geolocation2_debug = 1`, reproduce, check **Manage → Error log**. Set back to `0` on production.
+
+## Manager permissions
+
+Editing the catalog requires `geolocation2_save` for the user policy.

--- a/docs/en/components/geolocation2/index.md
+++ b/docs/en/components/geolocation2/index.md
@@ -1,0 +1,70 @@
+---
+title: GeoLocation2
+description: MODX geodata — gl_* catalog, SxGeo, city picker modal, REST action.php
+author: Ibochkarev
+repository: https://github.com/Ibochkarev/GeoLocation2
+logo: https://modstore.pro/assets/extras/geolocation2/logo.png
+modstore: https://modstore.pro/packages/utilities/geolocation2
+categories: utilities
+items: [
+  { text: 'Quick start', link: 'quick-start' },
+  { text: 'System settings', link: 'settings' },
+  { text: 'Integration', link: 'integration' },
+  { text: 'Web API (action.php)', link: 'api-action' },
+  {
+    text: 'Snippets',
+    link: 'snippets',
+    items: [
+      { text: 'GeoLocation2Initialize', link: 'snippets/GeoLocation2Initialize' },
+      { text: 'GeoLocation2Current', link: 'snippets/GeoLocation2Current' },
+      { text: 'GeoLocation2Modal', link: 'snippets/GeoLocation2Modal' },
+      { text: 'GeoLocation2', link: 'snippets/GeoLocation2' },
+      { text: 'GeoLocation2Location', link: 'snippets/GeoLocation2Location' },
+      { text: 'GeoLocation2Data', link: 'snippets/GeoLocation2Data' },
+    ],
+  },
+  { text: 'FAQ', link: 'faq' },
+]
+---
+
+# GeoLocation2
+
+Country, region and city catalog in `gl_*` tables, IP lookup via SxGeo, front-end city picker (Bootstrap 5 modal) and REST endpoint `action.php`.
+
+## Features
+
+- Tables `gl_countries`, `gl_regions`, `gl_cities`, `gl_data` and a manager in the MODX admin
+- SxGeo (local `.dat` database, no external API on every request)
+- Session `$_SESSION['gl2']`: selected city, confirmed flag, CSRF token
+- Snippets for city lists, SxGeo lookup, `gl_data`, modal flow
+- CSV import/export from the manager
+- Optional Scheduler task for SxGeo auto-update
+
+## Requirements
+
+| Requirement | Version |
+|-------------|---------|
+| MODX Revolution | 3.0+ |
+| PHP | 8.2+ |
+
+## Installation
+
+1. [Connect ModStore](https://modstore.pro/info/connection).
+2. **Extras → Installer** → **Download Extras** — **GeoLocation2** → **Download** → **Install**.
+3. **Manage → Clear cache**.
+4. Open **Components → GeoLocation2** and check catalog tabs.
+5. Confirm SxGeo file exists: `assets/components/geolocation2/vendor/sypexgeo/data/SxGeoCity.dat`.
+6. Add snippets to the site — see [Quick start](quick-start).
+
+Package catalog: [modstore.pro](https://modstore.pro/packages/utilities/geolocation2). Source: [GitHub](https://github.com/Ibochkarev/GeoLocation2).
+
+## Quick links
+
+| Section | Description |
+|---------|-------------|
+| [Quick start](quick-start) | Minimal site setup |
+| [System settings](settings) | `geolocation2_*` keys |
+| [Integration](integration) | Manager, data model, CSV, PHP service, SxGeo |
+| [Web API](api-action) | GET/POST `action.php` |
+| [Snippets](snippets/) | Parameters and chunks |
+| [FAQ](faq) | Common issues |

--- a/docs/en/components/geolocation2/integration.md
+++ b/docs/en/components/geolocation2/integration.md
@@ -1,0 +1,112 @@
+---
+title: Integration
+description: gl_* manager, data model, CSV, GeoLocation2 PHP service, SxGeo update
+---
+
+# Integration
+
+## Manager
+
+**Components → GeoLocation2** tabs:
+
+| Tab | Table | Content |
+|-----|-------|---------|
+| Countries | `gl_countries` | ISO, timezone, default country |
+| Regions | `gl_regions` | Region linked to country |
+| Cities | `gl_cities` | City, region, coordinates, default flag |
+| Data | `gl_data` | Contacts, address, image, alt name for a city |
+
+CSV import and export are available in the manager UI.
+
+## Data model
+
+```
+gl_countries
+  └── gl_regions
+        └── gl_cities
+              └── gl_data (0..n per city)
+```
+
+User session (`$_SESSION['gl2']`, key from service):
+
+| Session field | Purpose |
+|---------------|---------|
+| `city_id` | ID from `gl_cities` |
+| `confirmed` | User confirmed or picked a city |
+| `dismissed` | Modal closed without choice (when applicable) |
+| `csrf` | Token for POST to `action.php` |
+
+## PHP service
+
+```php
+/** @var \GeoLocation2\Service\GeoLocation2 $gl2 */
+$gl2 = $modx->services->get('GeoLocation2');
+
+$cityId = $gl2->getCurrentCityId();
+$state = $gl2->getSessionState();
+$gl2->setCity($cityId, true);
+```
+
+See `core/components/geolocation2/src/Service/` for methods and events.
+
+## SxGeo
+
+Database file:
+
+```text
+assets/components/geolocation2/vendor/sypexgeo/data/SxGeoCity.dat
+```
+
+With `geolocation2_detect_method = sxgeo`, first visit without session: IP → SxGeo → match against `gl_cities`.
+
+### SxGeo update
+
+**CLI** (from MODX root):
+
+```bash
+php assets/components/geolocation2/bin/update-sxgeo.php
+```
+
+**Scheduler** (MODX 3): task `geolocation2_update_sxgeo`. Enable `geolocation2_sxgeo_auto_update` and set `geolocation2_sxgeo_update_interval_days`.
+
+PHP-FPM restart is not required: new `.dat` is picked up on next SxGeo read.
+
+## Fenom and placeholders
+
+Current city in template:
+
+::: code-group
+
+```fenom
+{$_modx->runSnippet('!GeoLocation2Current', ['tpl' => 'tpl.GeoLocation2.current'])}
+```
+
+```modx
+[[!GeoLocation2Current? &tpl=`tpl.GeoLocation2.current`]]
+```
+
+:::
+
+Chunk placeholders depend on `tpl`; `tpl.GeoLocation2.current` usually exposes `[[+city_name]]`, `[[+region_name]]`, `[[+country_name]]`.
+
+## miniShop and delivery
+
+GeoLocation2 does not change the cart. Typical flow:
+
+1. User picks a city in the modal.
+2. Pass `city_id` from session to a delivery snippet or order options.
+3. Use `gl_data` for phone/address of a pickup point in the selected city.
+
+## Package chunks
+
+| Chunk | Purpose |
+|-------|---------|
+| `tpl.GeoLocation2.current` | Current city (modal trigger) |
+| `tpl.GeoLocation2.modal` | Bootstrap 5 modal markup |
+| `tpl.GeoLocation2.modal.item` | City row in modal list |
+| `tpl.GeoLocation2.item` | Row in `GeoLocation2` list |
+| `tpl.GeoLocation2.location` | SxGeo lookup output |
+| `tpl.GeoLocation2.data.item` | `gl_data` table row |
+| `tpl.GeoLocation2.data.current` | `gl_data` card for current city |
+
+See [Web API](api-action) and [snippets](snippets/).

--- a/docs/en/components/geolocation2/quick-start.md
+++ b/docs/en/components/geolocation2/quick-start.md
@@ -1,0 +1,85 @@
+---
+title: Quick start
+description: Minimal GeoLocation2 setup — initialize, modal, current city
+---
+
+# Quick start
+
+## 1. Settings
+
+In **System → System Settings → geolocation2** set:
+
+| Key | Recommended for start |
+|-----|----------------------|
+| `geolocation2_detect_method` | `sxgeo` — detect by IP on first visit |
+| `geolocation2_debug` | `0` in production, `1` while debugging |
+
+Details: [System settings](settings).
+
+## 2. Site template
+
+In `<head>` or before `</body>` add initialization (CSS/JS and Bootstrap 5 if not already on the page):
+
+::: code-group
+
+```fenom
+{'!GeoLocation2Initialize' | snippet}
+```
+
+```modx
+[[!GeoLocation2Initialize]]
+```
+
+:::
+
+Parameters `loadBootstrap`, `loadCss`, `loadJs` — see [GeoLocation2Initialize](snippets/GeoLocation2Initialize).
+
+## 3. Modal and current city
+
+In header or footer:
+
+::: code-group
+
+```fenom
+{'!GeoLocation2Current' | snippet : [
+  'tpl' => 'tpl.GeoLocation2.current'
+]}
+{'!GeoLocation2Modal' | snippet}
+```
+
+```modx
+[[!GeoLocation2Current? &tpl=`tpl.GeoLocation2.current`]]
+[[!GeoLocation2Modal]]
+```
+
+:::
+
+Chunk `tpl.GeoLocation2.current` ships with the package. Use `data-gl2-open="1"` on the button to open the modal.
+
+## 4. Verify
+
+1. Open the site in a private window.
+2. Modal should offer a city (SxGeo) or a city list.
+3. After selection the city is stored in `$_SESSION['gl2']`.
+4. `GET /assets/components/geolocation2/action.php?action=state` (with `X-Requested-With`) returns JSON with `state`, `confirmed` and session fields.
+
+## 5. City data
+
+If you filled `gl_data` in the manager:
+
+::: code-group
+
+```fenom
+{'!GeoLocation2Data' | snippet : [
+  'forCurrent' => 1,
+  'tpl' => 'tpl.GeoLocation2.data.current'
+]}
+```
+
+```modx
+[[!GeoLocation2Data? &forCurrent=`1` &tpl=`tpl.GeoLocation2.data.current`]]
+```
+
+:::
+
+Next: [Integration](integration), [Web API](api-action), [FAQ](faq).

--- a/docs/en/components/geolocation2/settings.md
+++ b/docs/en/components/geolocation2/settings.md
@@ -1,0 +1,36 @@
+---
+title: System settings
+description: geolocation2 namespace keys in MODX
+---
+
+# System settings
+
+Namespace: **geolocation2**. Database keys use prefix `geolocation2_`.
+
+## Main
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `geolocation2_debug` | boolean | `0` | Log to MODX error log |
+| `geolocation2_detect_method` | text | `sxgeo` | Initial detection: `sxgeo` (IP → SxGeo) or `session` (saved session only) |
+
+## SxGeo
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `geolocation2_sxgeo_auto_update` | boolean | `1` | Auto-update database via Scheduler |
+| `geolocation2_sxgeo_update_interval_days` | number | `14` | Days between update checks |
+| `geolocation2_sxgeo_last_run_at` | text | *(empty)* | Service: last task run time |
+| `geolocation2_sxgeo_last_status` | text | *(empty)* | Service: last update status |
+| `geolocation2_sxgeo_last_message` | text | *(empty)* | Service: last update message |
+| `geolocation2_sxgeo_last_header_time` | text | *(empty)* | Service: date from downloaded file header |
+
+Component writes `geolocation2_sxgeo_last_*` on auto-update and CLI. You normally do not edit them manually.
+
+## Permissions
+
+| Identifier | Purpose |
+|------------|---------|
+| `geolocation2_save` | Save records in GeoLocation2 manager |
+
+See also: [Integration → SxGeo update](integration#sxgeo-update).

--- a/docs/en/components/geolocation2/snippets/GeoLocation2.md
+++ b/docs/en/components/geolocation2/snippets/GeoLocation2.md
@@ -1,0 +1,57 @@
+---
+title: GeoLocation2
+description: Active cities list from gl_cities
+---
+
+# GeoLocation2
+
+Lists **active** cities from `gl_cities`. Each row is one chunk pass. Does not touch session or modal: static catalog for menus or sitemaps.
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tpl` | `tpl.GeoLocation2.item` | Row chunk |
+| `sortby` | `name_ru` | Sort field |
+| `sortdir` | `ASC` | `ASC` or `DESC` |
+| `limit` | `10` | Max rows; `0` = all active |
+| `region_id` | *(empty)* | Filter by `gl_regions.id` |
+| `outputSeparator` | newline | Between rows |
+| `toPlaceholder` | *(empty)* | Placeholder instead of output |
+
+## Call
+
+::: code-group
+
+```modx
+[[!GeoLocation2]]
+[[!GeoLocation2? &limit=`0`]]
+[[!GeoLocation2? &region_id=`5`]]
+```
+
+```fenom
+{'!GeoLocation2' | snippet : ['limit' => 0, 'region_id' => 5]}
+```
+
+:::
+
+## Output example
+
+Default chunk for two cities:
+
+```html
+<p><strong>Moscow</strong> Moscow — region id: 1 55.7558 37.6173</p>
+<p><strong>Kazan</strong> Kazan — region id: 2 55.7963 49.1088</p>
+```
+
+Row placeholders are `GlCity` fields: `id`, `name_ru`, `name_en`, `region_id`, `lat`, `lon`, etc.
+
+## vs modal
+
+| | GeoLocation2 | GeoLocation2Modal |
+|---|--------------|-------------------|
+| Source | `gl_cities` only | Session + SxGeo + search API |
+| Page cache | List can be cached separately | Modal/Initialize must be uncached |
+| City pick | No | Yes |
+
+See [GeoLocation2Modal](GeoLocation2Modal).

--- a/docs/en/components/geolocation2/snippets/GeoLocation2Current.md
+++ b/docs/en/components/geolocation2/snippets/GeoLocation2Current.md
@@ -1,0 +1,73 @@
+---
+title: GeoLocation2Current
+description: Current city from GeoLocation2 session — chunk or JSON
+---
+
+# GeoLocation2Current
+
+Shows the city the component treats as current: from session, SxGeo (before session exists), or default row in `gl_cities`. Uses `buildWebPlaceholders()` from the GeoLocation2 service.
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tpl` | `tpl.GeoLocation2.current` | HTML chunk |
+| `asJson` | `0` | Return JSON of `gl2_*` placeholders instead of chunk |
+| `toPlaceholder` | `0` | Write output to placeholder |
+
+## Call
+
+::: code-group
+
+```modx
+[[!GeoLocation2Current]]
+[[!GeoLocation2Current? &tpl=`tpl.GeoLocation2.current`]]
+[[!GeoLocation2Current? &asJson=`1`]]
+```
+
+```fenom
+{'!GeoLocation2Current' | snippet}
+{'!GeoLocation2Current' | snippet : ['asJson' => 1]}
+```
+
+:::
+
+## `gl2_*` placeholders
+
+Available in chunk and JSON when `asJson=1`:
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `gl2_current_id` | City ID in `gl_cities` |
+| `gl2_current_name_ru` | Name (RU) |
+| `gl2_current_name_en` | Name (EN) |
+| `gl2_display_name_ru` | Name in modal question (may use SxGeo) |
+| `gl2_real_name_ru` | City from SxGeo |
+| `gl2_default_id` / `gl2_default_name_ru` | City with default flag |
+| `gl2_confirmed` / `gl2_prompt_done` | `1` after user confirmed |
+| `gl2_csrf` | Token for POST to `action.php` |
+
+## Default chunk output
+
+`tpl.GeoLocation2.current`:
+
+```html
+<span class="gl2-current-city" data-city-id="1" data-confirmed="0">Moscow</span>
+```
+
+`data-confirmed="0"` until modal confirm, `"1"` after.
+
+Custom chunk: button with `data-gl2-open="1"` to open [GeoLocation2Modal](GeoLocation2Modal).
+
+## JSON example (`asJson=1`)
+
+```json
+{
+  "gl2_current_id": "1",
+  "gl2_current_name_ru": "Moscow",
+  "gl2_confirmed": "0",
+  "gl2_csrf": "a1b2c3…"
+}
+```
+
+See [GeoLocation2Modal](GeoLocation2Modal), [Web API](../api-action).

--- a/docs/en/components/geolocation2/snippets/GeoLocation2Data.md
+++ b/docs/en/components/geolocation2/snippets/GeoLocation2Data.md
@@ -1,0 +1,74 @@
+---
+title: GeoLocation2Data
+description: Contacts and address from gl_data
+---
+
+# GeoLocation2Data
+
+Outputs `gl_data` rows: email, phone, address, image, alt name, `properties` JSON. Data from **Data** tab in GeoLocation2 manager.
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tpl` | `tpl.GeoLocation2.data.item` | Row chunk |
+| `sortby` | `id` | Sort field |
+| `sortdir` | `DESC` | `ASC` / `DESC` |
+| `limit` | `0` | Limit; `0` = none |
+| `class` | *(empty)* | `GlCountry`, `GlRegion`, `GlCity` |
+| `identifier` | *(empty)* | Object ID in class table |
+| `onlyDefault` | `0` | Only `default=1` |
+| `forCurrent` | `0` | Rows for current city from session |
+| `liveUpdate` | same as `forCurrent` | Wrap in `[data-gl2-data-live]`, refresh via API |
+| `outputSeparator` | newline | Between rows |
+| `toPlaceholder` | *(empty)* | Placeholder instead of output |
+
+## Current city
+
+::: code-group
+
+```modx
+[[!GeoLocation2Data? &forCurrent=`1` &tpl=`tpl.GeoLocation2.data.current`]]
+```
+
+```fenom
+{'!GeoLocation2Data' | snippet : ['forCurrent' => 1, 'tpl' => 'tpl.GeoLocation2.data.current']}
+```
+
+:::
+
+Uses same session as [GeoLocation2Modal](GeoLocation2Modal).
+
+## Output example
+
+**Card** `tpl.GeoLocation2.data.current`:
+
+```html
+<div class="gl2-data-current" data-gl2-data-id="3">
+  <dl>
+    <dt>Email / phone</dt>
+    <dd>info@example.com · +7 …</dd>
+    …
+  </dl>
+</div>
+```
+
+**Table row** `tpl.GeoLocation2.data.item`:
+
+```html
+<tr class="gl2-data-row" data-gl2-data-id="3" data-gl2-data-class="GlCity" data-gl2-data-identifier="1">
+  <td>3</td>
+  <td>GlCity</td>
+  …
+</tr>
+```
+
+Extra placeholders: `default_label`, `default_pill_class`, `image_display`, `properties_json`.
+
+## Live update
+
+With `forCurrent=1`, default `liveUpdate=1` wraps output in `[data-gl2-data-live]`. After city change, `modal.js` calls `GET action=data` and replaces HTML.
+
+Disable: `&liveUpdate=`0``.
+
+See [Web API → action=data](../api-action), [GeoLocation2Modal](GeoLocation2Modal).

--- a/docs/en/components/geolocation2/snippets/GeoLocation2Initialize.md
+++ b/docs/en/components/geolocation2/snippets/GeoLocation2Initialize.md
@@ -1,0 +1,59 @@
+---
+title: GeoLocation2Initialize
+description: GeoLocation2 modal CSS/JS and action.php config
+---
+
+# GeoLocation2Initialize
+
+Loads modal assets and sets global config for `modal.js`. Nothing visible on the page: output is `<link>`, `<script>` tags and `window.GeoLocation2Web`.
+
+Call **once** on any page that uses [GeoLocation2Modal](GeoLocation2Modal) or `[data-gl2-data-live]` blocks.
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `loadBootstrap` | `0` | Bootstrap 5.3 from jsDelivr (CSS + bundle JS) |
+| `loadCss` | `1` | `assets/.../css/web/modal.css` |
+| `loadJs` | `1` | `assets/.../js/web/modal.js` (defer) |
+| `toPlaceholder` | `0` | Write output to placeholder instead of echo |
+
+If Bootstrap 5 is already in the theme, keep `loadBootstrap=0`.
+
+## Call
+
+::: code-group
+
+```modx
+[[!GeoLocation2Initialize]]
+[[!GeoLocation2Initialize? &loadBootstrap=`1`]]
+```
+
+```fenom
+{'!GeoLocation2Initialize' | snippet}
+{'!GeoLocation2Initialize' | snippet : ['loadBootstrap' => 1, 'loadCss' => 1, 'loadJs' => 1]}
+```
+
+:::
+
+## HTML output
+
+Simplified fragment:
+
+```html
+<link rel="stylesheet" href="/assets/components/geolocation2/css/web/modal.css?v=…">
+<script>window.GeoLocation2Web = Object.assign({}, window.GeoLocation2Web || {}, {"actionUrl":"/assets/components/geolocation2/action.php","messages":{"networkError":"…"}});</script>
+<script src="/assets/components/geolocation2/js/web/modal.js?v=…" defer></script>
+```
+
+With `loadBootstrap=1`, Bootstrap 5.3.3 CDN links are added.
+
+## Related snippets
+
+| Snippet | Dependency |
+|---------|------------|
+| GeoLocation2Modal | Needs CSS/JS; without Initialize use `includeAssets=1` on Modal (legacy) |
+| GeoLocation2Data + `liveUpdate` | `modal.js` calls `action=data` after city change |
+| GeoLocation2Current | Does not require Initialize |
+
+See [GeoLocation2Modal](GeoLocation2Modal), [FAQ](../faq).

--- a/docs/en/components/geolocation2/snippets/GeoLocation2Location.md
+++ b/docs/en/components/geolocation2/snippets/GeoLocation2Location.md
@@ -1,0 +1,56 @@
+---
+title: GeoLocation2Location
+description: Visitor geolocation by IP via SxGeo
+---
+
+# GeoLocation2Location
+
+Takes visitor IP (or `ip` param), reads local SxGeo database, renders chunk with flat `city_*`, `region_*`, `country_*` placeholders. Does not change `gl_cities` or session.
+
+Useful to debug SxGeo or show “detected region” without [GeoLocation2Modal](GeoLocation2Modal).
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tpl` | `tpl.GeoLocation2.location` | Output chunk |
+| `ip` | visitor IP | Explicit IP for tests |
+| `toPlaceholder` | *(empty)* | Placeholder instead of echo |
+
+## Call
+
+::: code-group
+
+```modx
+[[!GeoLocation2Location]]
+[[!GeoLocation2Location? &ip=`8.8.8.8`]]
+```
+
+```fenom
+{'!GeoLocation2Location' | snippet : ['ip' => '8.8.8.8']}
+```
+
+:::
+
+## Placeholders
+
+1. `getCityFullByIp()` → nested SxGeo array.
+2. Flattened to `city_name_ru`, `region_name_ru`, …
+3. `processData()` adds `city_name_ru_html`, `country_iso_html`, etc.
+
+Keys depend on `SxGeoCity.dat` edition. Enable `geolocation2_debug` if chunk is empty.
+
+## Output example
+
+```html
+<div class="geolocation2-location">
+    <span>Moscow</span>
+    …
+</div>
+```
+
+## Empty output
+
+Returns empty string when `.dat` is missing, IP not found (`127.0.0.1` on localhost), or service not registered.
+
+See [Integration → SxGeo](../integration), [FAQ](../faq).

--- a/docs/en/components/geolocation2/snippets/GeoLocation2Modal.md
+++ b/docs/en/components/geolocation2/snippets/GeoLocation2Modal.md
@@ -1,0 +1,80 @@
+---
+title: GeoLocation2Modal
+description: Bootstrap 5 city confirm and change modal
+---
+
+# GeoLocation2Modal
+
+Renders Bootstrap 5 modal and “Your city” toolbar. Uses session, CSRF and [action.php](../api-action). Sets `gl2_*` placeholders on the page (used by [GeoLocation2Current](GeoLocation2Current) and Fenom).
+
+Load [GeoLocation2Initialize](GeoLocation2Initialize) before the modal, or pass `includeAssets=1` (legacy single-snippet mode).
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `tpl` | `tpl.GeoLocation2.modal` | Modal + toolbar chunk |
+| `itemTpl` | `tpl.GeoLocation2.modal.item` | City row in list |
+| `modalShow` | `1` | Auto-show on first visit |
+| `includeAssets` | `0` | Inline CSS/JS from this snippet |
+| `loadBootstrap` | `0` | Bootstrap 5 CDN (with `includeAssets=1`) |
+| `preferRealWhenDefault` | `1` | Show SxGeo name in question when default city |
+| `dismissSetsDefault` | `1` | Close with X → default city |
+| `modalId` | `geolocation2Modal` | HTML `id` |
+| `unknownCityLabel` | lexicon | Unknown city label |
+| `defaultCityLabel` | lexicon | Default city label |
+| `toPlaceholder` | `0` | Output to placeholder |
+
+## Call
+
+::: code-group
+
+```modx
+[[!GeoLocation2Initialize]]
+[[!GeoLocation2Modal? &modalShow=`1`]]
+[[!GeoLocation2Current]]
+```
+
+```fenom
+{'!GeoLocation2Initialize' | snippet}
+{'!GeoLocation2Modal' | snippet : ['modalShow' => 1]}
+{'!GeoLocation2Current' | snippet}
+```
+
+:::
+
+## Behavior
+
+1. **Confirm step** — “Your city — **Moscow**?” Buttons Yes (`action=confirm`) and Change (list step).
+2. **List step** — search field and city list. Search uses `action=search` for cached pages. Initial HTML also lists cities from DB (no-JS fallback).
+3. **Toolbar** below modal — current city and `.gl2-open-modal` link.
+
+With `modalShow=1` and `gl2_confirmed=0`, script opens modal after load.
+
+## Markup fragment
+
+From `tpl.GeoLocation2.modal` (simplified):
+
+```html
+<div class="modal fade geolocation2-modal" id="geolocation2Modal"
+     data-gl2-root data-gl2-action-url="/assets/components/geolocation2/action.php"
+     data-gl2-csrf="…" data-gl2-modal-show="1">
+  …
+</div>
+<p class="geolocation2-toolbar">
+  <strong class="gl2-toolbar-city">Moscow</strong>
+  <a href="#" class="gl2-open-modal">Change</a>
+</p>
+```
+
+## POST to action.php
+
+| Action | When |
+|--------|------|
+| `confirm` | Yes on confirm step |
+| `save` | Pick city from list |
+| `dismiss` | Close via X or backdrop |
+
+Each POST needs `csrf` from `data-gl2-csrf` and header `X-Requested-With: XMLHttpRequest`.
+
+See [GeoLocation2Initialize](GeoLocation2Initialize), [GeoLocation2Current](GeoLocation2Current).

--- a/docs/en/components/geolocation2/snippets/index.md
+++ b/docs/en/components/geolocation2/snippets/index.md
@@ -1,0 +1,43 @@
+---
+title: Snippets
+description: GeoLocation2 snippets overview
+---
+
+# GeoLocation2 snippets
+
+| Snippet | Purpose |
+|---------|---------|
+| [GeoLocation2Initialize](GeoLocation2Initialize) | Modal CSS/JS and `window.GeoLocation2Web` |
+| [GeoLocation2Current](GeoLocation2Current) | Current city in header or JSON state |
+| [GeoLocation2Modal](GeoLocation2Modal) | City confirm/change modal |
+| [GeoLocation2](GeoLocation2) | City list from `gl_cities` |
+| [GeoLocation2Location](GeoLocation2Location) | City/region/country by IP via SxGeo |
+| [GeoLocation2Data](GeoLocation2Data) | Contacts and address from `gl_data` |
+
+## Page order
+
+1. [GeoLocation2Initialize](GeoLocation2Initialize) — once in template.
+2. [GeoLocation2Current](GeoLocation2Current) — “Your city” widget.
+3. [GeoLocation2Modal](GeoLocation2Modal) — modal markup (often in footer).
+4. [GeoLocation2Data](GeoLocation2Data) with `forCurrent=1` for selected city contacts.
+
+[GeoLocation2](GeoLocation2) and [GeoLocation2Location](GeoLocation2Location) are independent of the modal: static list vs raw SxGeo output.
+
+Front-end calls must be **uncached** (`[[!...]]`, `{'!...' | snippet}`), otherwise CSRF and session city go stale.
+
+## MODX / Fenom
+
+| Task | MODX | Fenom |
+|------|------|-------|
+| Initialize | `[[!GeoLocation2Initialize]]` | `{'!GeoLocation2Initialize' \| snippet}` |
+| Current city | `[[!GeoLocation2Current]]` | `{'!GeoLocation2Current' \| snippet}` |
+| Modal | `[[!GeoLocation2Modal]]` | `{'!GeoLocation2Modal' \| snippet}` |
+| City list | `[[!GeoLocation2? &limit=`0`]]` | `{'!GeoLocation2' \| snippet : ['limit' => 0]}` |
+| SxGeo | `[[!GeoLocation2Location]]` | `{'!GeoLocation2Location' \| snippet}` |
+| City data | `[[!GeoLocation2Data? &forCurrent=`1`]]` | `{'!GeoLocation2Data' \| snippet : ['forCurrent' => 1]}` |
+
+## See also
+
+- [Web API](../api-action)
+- [Quick start](../quick-start)
+- [Integration](../integration)


### PR DESCRIPTION
Документация GeoLocation2 на docs.modx.pro по пакету 1.0.0-pl и репозиторию https://github.com/Ibochkarev/GeoLocation2.

Структура: index, quick-start, settings, integration, Web API (action.php), FAQ. Шесть сниппетов на отдельных страницах с примерами вывода и MODX/Fenom. Зеркало RU/EN для CI docs-sync. В cspell.json добавлены термины пакета.

Установка описана в стиле других дополнений автора (ModStore connection). Frontmatter: author Ibochkarev, repository, modstore utilities/geolocation2.