### PR TITLE
docs: выровнять logo и modstore у пакетов Ibochkarev

### DIFF
--- a/docs/components/bannerpro/index.md
+++ b/docs/components/bannerpro/index.md
@@ -1,8 +1,8 @@
 ---
 title: BannerPro
 description: "BannerPro: баннеры в MODX 3, позиции, UTM, webhook, A/B, REST API, Vue-админка"
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/bannerpro/logo-md.png
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/bannerpro/logo.png
 modstore: https://modstore.pro/packages/photos-and-files/bannerpro
 dependencies: [pdoTools, VueTools]
 

--- a/docs/components/crawlerdetect/index.md
+++ b/docs/components/crawlerdetect/index.md
@@ -1,10 +1,10 @@
 ---
 title: CrawlerDetect
 description: Определение веб-краулеров по User-Agent и защита форм от спама без CAPTCHA
-author: ibochkarev
-repository: https://github.com/Ibochkarev/CrawlerDetect
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/crawlerdetect/logo.png
-modstore: https://modstore.pro/packages/utilities/crawlerdetect
+modstore: https://modstore.pro/packages/other/crawlerdetect
+repository: https://github.com/Ibochkarev/CrawlerDetect
 
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/geolocation2/index.md
+++ b/docs/components/geolocation2/index.md
@@ -2,9 +2,9 @@
 title: GeoLocation2
 description: Геоданные MODX — справочник gl_*, SxGeo, модалка выбора города, REST action.php
 author: Ibochkarev
-repository: https://github.com/Ibochkarev/GeoLocation2
 logo: https://modstore.pro/assets/extras/geolocation2/logo.png
-modstore: https://modstore.pro/packages/utilities/geolocation2
+modstore: https://modstore.pro/packages/maps/geolocation2
+repository: https://github.com/Ibochkarev/GeoLocation2
 categories: utilities
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/imageoptimizer/index.md
+++ b/docs/components/imageoptimizer/index.md
@@ -1,10 +1,10 @@
 ---
 title: ImageOptimizer
 description: Конвертация изображений в WebP/AVIF, responsive srcset, очередь и авто-inject picture на витрине MODX 3
-author: ibochkarev
-repository: https://github.com/Ibochkarev/ImageOptimizer
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/imageoptimizer/logo.png
-modstore: https://modstore.pro/packages/utilities/imageoptimizer
+modstore: https://modstore.pro/packages/photos-and-files/imageoptimizer
+repository: https://github.com/Ibochkarev/ImageOptimizer
 categories: utilities
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/indexnow/index.md
+++ b/docs/components/indexnow/index.md
@@ -1,7 +1,9 @@
 ---
 title: IndexNow
 description: Очередь URL и уведомление поисковиков по протоколу IndexNow
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/indexnow/logo.png
+modstore: https://modstore.pro/packages/utilities/indexnow
 categories: utilities
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/modx3ProfilerToolbar/index.md
+++ b/docs/components/modx3ProfilerToolbar/index.md
@@ -1,8 +1,9 @@
 ---
 title: Modx3ProfilerToolbar
 description: Тулбар производительности для MODX 3 — метрики запроса, медленные компоненты, таймлайн и SQL без админки
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/modx3profilertoolbar/logo.jpg
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/modx3profilertoolbar/logo.png
+modstore: https://modstore.pro/packages/other/modx3profilertoolbar
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },
   { text: 'Системные настройки', link: 'settings' },

--- a/docs/components/ms3favorites/index.md
+++ b/docs/components/ms3favorites/index.md
@@ -1,8 +1,9 @@
 ---
 title: ms3Favorites
 description: Списки избранного для MiniShop3 и других ресурсов — хранение в браузере, синхронизация в БД
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/ms3favorites/logo.png
-author: ibochkarev
+modstore: https://modstore.pro/packages/ecommerce/ms3favorites
 
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/ms3firsttimebuyerdiscount/index.md
+++ b/docs/components/ms3firsttimebuyerdiscount/index.md
@@ -1,8 +1,8 @@
 ---
 title: ms3FirstTimeBuyerDiscount
 description: Скидка на первый заказ для MiniShop3 — автоматическое применение при 0 оплаченных заказов (процент или фикс)
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/ms3firsttimebuyerdiscount/logo.png
-author: ibochkarev
 modstore: https://modstore.pro/packages/discounts/ms3firsttimebuyerdiscount
 dependencies: miniShop3
 categories: minishop3

--- a/docs/components/ms3optionscolor/index.md
+++ b/docs/components/ms3optionscolor/index.md
@@ -1,7 +1,9 @@
 ---
 title: ms3OptionsColor
 description: "Свотчи для опций miniShop3: HEX, паттерны, изображения и RAL Classic"
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3optionscolor/logo.png
+modstore: https://modstore.pro/packages/ecommerce/ms3optionscolor
 dependencies:
   - miniShop3
   - VueTools

--- a/docs/components/ms3productsets/index.md
+++ b/docs/components/ms3productsets/index.md
@@ -1,8 +1,8 @@
 ---
 title: ms3ProductSets
 description: Динамические подборки товаров для MiniShop3 — ручные связи, авто-рекомендации, админка шаблонов
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/ms3productsets/logo.png
-author: ibochkarev
 modstore: https://modstore.pro/packages/ecommerce/ms3productsets
 dependencies: miniShop3
 categories: minishop3

--- a/docs/components/ms3pulse/index.md
+++ b/docs/components/ms3pulse/index.md
@@ -1,9 +1,9 @@
 ---
 title: ms3Pulse
 description: Дашборд продаж и аналитика для MiniShop3 — метрики, графики, экспорт и отчёты по расписанию
-logo: https://modstore.pro/assets/extras/ms3pulse/logo.jpg
-author: ibochkarev
-modstore: https://modstore.pro/packages/integration/ms3pulse
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3pulse/logo.png
+modstore: https://modstore.pro/packages/other/ms3pulse
 dependencies: [miniShop3, vuetools]
 categories: minishop3
 

--- a/docs/components/ms3recentlyviewed/index.md
+++ b/docs/components/ms3recentlyviewed/index.md
@@ -1,8 +1,9 @@
 ---
 title: ms3RecentlyViewed
 description: 'Блок «Недавно просмотренные товары» для MiniShop3 — хранение в браузере или БД, похожие товары, админка'
-logo: "https://modstore.pro/assets/extras/ms3recentlyviewed/logo.png?v=1"
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3recentlyviewed/logo.png
+modstore: https://modstore.pro/packages/ecommerce/ms3recentlyviewed
 
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/msbulkeditor/index.md
+++ b/docs/components/msbulkeditor/index.md
@@ -1,7 +1,9 @@
 ---
 title: msBulkEditor
 description: Массовое редактирование товаров MiniShop3 в менеджере MODX 3
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msbulkeditor/logo.png
+modstore: https://modstore.pro/packages/ecommerce/msbulkeditor
 dependencies: [miniShop3, VueTools]
 categories: minishop3
 

--- a/docs/components/msbundles/index.md
+++ b/docs/components/msbundles/index.md
@@ -1,7 +1,9 @@
 ---
 title: msBundles
 description: Комплекты товаров miniShop3 с общей ценой, скидкой и синхронизацией в корзине
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msbundles/logo.png
+modstore: https://modstore.pro/packages/ecommerce/msbundles
 dependencies:
   - miniShop3
   - VueTools

--- a/docs/components/mscurrency/index.md
+++ b/docs/components/mscurrency/index.md
@@ -1,9 +1,9 @@
 ---
 title: msCurrency
 description: Мультивалютность для MiniShop3
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/mscurrency/logo.png
-modstore: https://modstore.pro/packages/ecommerce/mscurrency
+modstore: https://modstore.pro/packages/integration/mscurrency
 dependencies: miniShop3
 categories: minishop3
 

--- a/docs/components/msfastorder/index.md
+++ b/docs/components/msfastorder/index.md
@@ -1,7 +1,7 @@
 ---
 title: msFastOrder
 description: Быстрый заказ в один клик через модальное окно для MODX 3 и MiniShop3
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msfastorder/logo.png
 modstore: https://modstore.pro/packages/integration/msfastorder
 dependencies: miniShop3

--- a/docs/components/msp3sberbank/index.md
+++ b/docs/components/msp3sberbank/index.md
@@ -1,11 +1,11 @@
 ---
 title: msp3Sberbank
 description: "Приём оплаты через Сбербанк для MiniShop3: redirect, callback, чеки 54-ФЗ, одно- и двухстадийная схема, deposit, reverse, refund"
-author: ibochkarev
-dependencies: miniShop3
-categories: minishop3
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msp3sberbank/logo.png
 modstore: https://modstore.pro/packages/payment-system/msp3sberbank
+dependencies: miniShop3
+categories: minishop3
 
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/msp3yookassa/index.md
+++ b/docs/components/msp3yookassa/index.md
@@ -1,11 +1,11 @@
 ---
 title: msp3YooKassa
 description: Приём оплаты через ЮKassa для MiniShop3 — одно- и двухстадийные платежи, webhook, чеки 54-ФЗ
-author: ibochkarev
-dependencies: miniShop3
-categories: minishop3
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msp3yookassa/logo.png
 modstore: https://modstore.pro/packages/payment-system/msp3yookassa
+dependencies: miniShop3
+categories: minishop3
 
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/mspricetiers/index.md
+++ b/docs/components/mspricetiers/index.md
@@ -1,8 +1,7 @@
 ---
 title: msPriceTiers
 description: Оптовые цены по количеству для MiniShop3 — пороги на товаре и категории, сумма корзины, шаблоны, массовые операции, ms3Variants
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/mspricetiers/logo.png
+author: Ibochkarev
 modstore: https://modstore.pro/packages/ecommerce/mspricetiers
 dependencies: miniShop3
 categories: minishop3

--- a/docs/components/msptbank/index.md
+++ b/docs/components/msptbank/index.md
@@ -1,7 +1,9 @@
 ---
 title: mspTBank
 description: "Приём оплаты через T-Bank для MiniShop3: redirect, webhook, чеки 54-ФЗ, одно- и двухстадийная схема, возвраты"
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msptbank/logo.png
+modstore: https://modstore.pro/packages/payment-system/msptbank
 dependencies: miniShop3
 categories: minishop3
 

--- a/docs/components/msreviews/index.md
+++ b/docs/components/msreviews/index.md
@@ -1,7 +1,7 @@
 ---
 title: msReviews
 description: Отзывы, рейтинг, Q&A и JSON-LD для MiniShop3
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msreviews/logo.png
 modstore: https://modstore.pro/packages/ecommerce/msreviews
 dependencies: miniShop3

--- a/docs/components/msrussianpost/index.md
+++ b/docs/components/msrussianpost/index.md
@@ -1,8 +1,9 @@
 ---
 title: msRussianPost
 description: Расчёт доставки Почтой России для MODX 3 и MiniShop3
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msrussianpost/logo.png
-author: ibochkarev
+modstore: https://modstore.pro/packages/delivery/msrussianpost
 
 items:
   - text: Быстрый старт

--- a/docs/components/msviewcounter/index.md
+++ b/docs/components/msviewcounter/index.md
@@ -1,7 +1,7 @@
 ---
 title: msViewCounter
 description: Счётчик просмотров и активных посетителей товара для MiniShop3
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msviewcounter/logo.png
 modstore: https://modstore.pro/packages/ecommerce/msviewcounter
 dependencies: miniShop3

--- a/docs/components/msyandexdelivery/index.md
+++ b/docs/components/msyandexdelivery/index.md
@@ -1,11 +1,11 @@
 ---
 title: msYandexDelivery
 description: Доставка через Yandex Delivery Platform API (other-day) для MiniShop3 — расчёт, ПВЗ, заявки в менеджере
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msyandexdelivery/logo.png
+modstore: https://modstore.pro/packages/delivery/msyandexdelivery
 dependencies: [miniShop3, VueTools]
 categories: minishop3
-logo: https://modstore.pro/assets/extras/msyandexdelivery/logo-md.png
-modstore: https://modstore.pro/packages/delivery/msyandexdelivery
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },
   { text: 'Системные настройки', link: 'settings' },

--- a/docs/components/mxdadata/index.md
+++ b/docs/components/mxdadata/index.md
@@ -1,7 +1,9 @@
 ---
 title: mxDadata
 description: Подсказки DaData и валидация адреса для MiniShop3 в MODX 3
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/mxdadata/logo.png
+modstore: https://modstore.pro/packages/utilities/mxdadata
 dependencies: minishop3
 categories: minishop3
 

--- a/docs/components/mxeditorjs/index.md
+++ b/docs/components/mxeditorjs/index.md
@@ -1,7 +1,7 @@
 ---
 title: mxEditorJs
 description: Блочный редактор Editor.js для MODX 3 — контент блоками вместо TinyMCE/CKEditor
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/mxeditorjs/logo.png
 modstore: https://modstore.pro/packages/content/mxeditorjs
 repository: https://github.com/Ibochkarev/mxEditorJs

--- a/docs/components/mxheadless/index.md
+++ b/docs/components/mxheadless/index.md
@@ -2,6 +2,8 @@
 title: mxHeadless
 description: REST API gateway для headless-фронтендов на MODX 3. Ресурсы, объекты, OpenAPI, API keys и OAuth
 author: Ibochkarev
+logo: https://modstore.pro/assets/extras/mxheadless/logo.png
+modstore: https://modstore.pro/packages/utilities/mxheadless
 repository: https://github.com/Ibochkarev/mxHeadless
 categories: utilities
 items: [

--- a/docs/components/mxquickview/index.md
+++ b/docs/components/mxquickview/index.md
@@ -1,8 +1,9 @@
 ---
 title: mxQuickView
 description: Быстрый просмотр карточки товара и любых ресурсов по AJAX для MODX 3
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/mxquickview/logo.jpg
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/mxquickview/logo.png
+modstore: https://modstore.pro/packages/ecommerce/mxquickview
 dependencies: ['minishop3', 'ms3Variants']
 
 items: [

--- a/docs/components/phonespamdetect/index.md
+++ b/docs/components/phonespamdetect/index.md
@@ -1,10 +1,10 @@
 ---
 title: PhoneSpamDetect
 description: Валидация телефонов в формах MODX через Google libphonenumber — локально, без API-ключей
-author: ibochkarev
-repository: https://github.com/Ibochkarev/PhoneSpamDetect
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/phonespamdetect/logo.png
-modstore: https://modstore.pro/packages/utilities/phonespamdetect
+modstore: https://modstore.pro/packages/other/phonespamdetect
+repository: https://github.com/Ibochkarev/PhoneSpamDetect
 
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/components/reactions/index.md
+++ b/docs/components/reactions/index.md
@@ -1,9 +1,10 @@
 ---
 title: Reactions
 description: Универсальная система реакций для MODX 3 — лайки, наборы в стиле GitHub, топы и trending на любом объекте
-author: ibochkarev
-repository: https://github.com/Ibochkarev/Reactions
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/reactions/logo.png
+modstore: https://modstore.pro/packages/ecommerce/reactions
+repository: https://github.com/Ibochkarev/Reactions
 categories: utilities
 
 items: [

--- a/docs/components/yandexmapslocator/index.md
+++ b/docs/components/yandexmapslocator/index.md
@@ -3,7 +3,7 @@ title: YandexMapsLocator
 description: 'Локатор точек на Яндекс.Картах для MODX 3. Free: карта и поиск. Pro: «открыто сейчас», MiniShop3, CSV и REST'
 author: Ibochkarev
 logo: https://modstore.pro/assets/extras/yandexmapslocator/logo.png
-modstore: https://modstore.pro/packages/utilities/yandexmapslocator
+modstore: https://modstore.pro/packages/maps/yandexmapslocator
 categories: utilities
 items: [
   {

--- a/docs/en/components/bannerpro/index.md
+++ b/docs/en/components/bannerpro/index.md
@@ -1,8 +1,8 @@
 ---
 title: BannerPro
 description: "Banner management for MODX 3: positions, rotation, clicks, impressions, and Vue manager UI"
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/bannerpro/logo-md.png
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/bannerpro/logo.png
 modstore: https://modstore.pro/packages/photos-and-files/bannerpro
 dependencies: [pdoTools, VueTools]
 

--- a/docs/en/components/crawlerdetect/index.md
+++ b/docs/en/components/crawlerdetect/index.md
@@ -1,10 +1,10 @@
 ---
 title: CrawlerDetect
 description: Detect web crawlers by User-Agent and protect forms from spam without CAPTCHA
-author: ibochkarev
-repository: https://github.com/Ibochkarev/CrawlerDetect
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/crawlerdetect/logo.png
-modstore: https://modstore.pro/packages/utilities/crawlerdetect
+modstore: https://modstore.pro/packages/other/crawlerdetect
+repository: https://github.com/Ibochkarev/CrawlerDetect
 
 items: [
   { text: 'Quick start', link: 'quick-start' },

--- a/docs/en/components/geolocation2/index.md
+++ b/docs/en/components/geolocation2/index.md
@@ -2,9 +2,9 @@
 title: GeoLocation2
 description: MODX geodata — gl_* catalog, SxGeo, city picker modal, REST action.php
 author: Ibochkarev
-repository: https://github.com/Ibochkarev/GeoLocation2
 logo: https://modstore.pro/assets/extras/geolocation2/logo.png
-modstore: https://modstore.pro/packages/utilities/geolocation2
+modstore: https://modstore.pro/packages/maps/geolocation2
+repository: https://github.com/Ibochkarev/GeoLocation2
 categories: utilities
 items: [
   { text: 'Quick start', link: 'quick-start' },

--- a/docs/en/components/indexnow/index.md
+++ b/docs/en/components/indexnow/index.md
@@ -1,7 +1,9 @@
 ---
 title: IndexNow
 description: Очередь URL и уведомление поисковиков по протоколу IndexNow
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/indexnow/logo.png
+modstore: https://modstore.pro/packages/utilities/indexnow
 categories: utilities
 items: [
   { text: 'Быстрый старт', link: 'quick-start' },

--- a/docs/en/components/modx3ProfilerToolbar/index.md
+++ b/docs/en/components/modx3ProfilerToolbar/index.md
@@ -1,8 +1,9 @@
 ---
 title: Modx3ProfilerToolbar
 description: Performance toolbar for MODX 3 — request metrics, slow components, timeline and SQL without admin
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/modx3profilertoolbar/logo.jpg
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/modx3profilertoolbar/logo.png
+modstore: https://modstore.pro/packages/other/modx3profilertoolbar
 items: [
   { text: 'Quick start', link: 'quick-start' },
   { text: 'System settings', link: 'settings' },

--- a/docs/en/components/ms3favorites/index.md
+++ b/docs/en/components/ms3favorites/index.md
@@ -1,8 +1,9 @@
 ---
 title: ms3Favorites
 description: 'Wishlists for MiniShop3 and other resources — browser storage, DB sync'
-logo: "https://modstore.pro/assets/extras/ms3favorites/logo.png"
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3favorites/logo.png
+modstore: https://modstore.pro/packages/ecommerce/ms3favorites
 
 items: [
   { text: 'Quick start', link: 'quick-start' },

--- a/docs/en/components/ms3firsttimebuyerdiscount/index.md
+++ b/docs/en/components/ms3firsttimebuyerdiscount/index.md
@@ -1,8 +1,8 @@
 ---
 title: ms3FirstTimeBuyerDiscount
 description: First-order discount for MiniShop3 — auto-applied when 0 paid orders (percent or fixed)
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/ms3firsttimebuyerdiscount/logo.png
-author: ibochkarev
 modstore: https://modstore.pro/packages/discounts/ms3firsttimebuyerdiscount
 dependencies: miniShop3
 categories: minishop3

--- a/docs/en/components/ms3optionscolor/index.md
+++ b/docs/en/components/ms3optionscolor/index.md
@@ -1,7 +1,9 @@
 ---
 title: ms3OptionsColor
 description: "Swatches for miniShop3 options: HEX, patterns, images, and RAL Classic"
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3optionscolor/logo.png
+modstore: https://modstore.pro/packages/ecommerce/ms3optionscolor
 dependencies:
   - miniShop3
   - VueTools

--- a/docs/en/components/ms3productsets/index.md
+++ b/docs/en/components/ms3productsets/index.md
@@ -1,8 +1,9 @@
 ---
 title: ms3ProductSets
 description: Dynamic product recommendations for MiniShop3 — manual links, auto rules, manager templates
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/ms3productsets/logo.png
-author: ibochkarev
+modstore: https://modstore.pro/packages/ecommerce/ms3productsets
 
 items: [
   { text: 'Quick start', link: 'quick-start' },

--- a/docs/en/components/ms3pulse/index.md
+++ b/docs/en/components/ms3pulse/index.md
@@ -1,8 +1,9 @@
 ---
 title: ms3Pulse
 description: Sales dashboard and analytics for MiniShop3 — metrics, charts, export and scheduled reports
-logo: https://modstore.pro/assets/extras/ms3pulse/logo.jpg
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3pulse/logo.png
+modstore: https://modstore.pro/packages/other/ms3pulse
 
 items: [
   { text: 'Quick start', link: 'quick-start' },

--- a/docs/en/components/ms3recentlyviewed/index.md
+++ b/docs/en/components/ms3recentlyviewed/index.md
@@ -1,8 +1,9 @@
 ---
 title: ms3RecentlyViewed
 description: '"Recently viewed products" block for MiniShop3 — browser or DB storage, similar products, manager'
-logo: "https://modstore.pro/assets/extras/ms3recentlyviewed/logo.png"
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/ms3recentlyviewed/logo.png
+modstore: https://modstore.pro/packages/ecommerce/ms3recentlyviewed
 
 items: [
   { text: 'Quick start', link: 'quick-start' },

--- a/docs/en/components/msbulkeditor/index.md
+++ b/docs/en/components/msbulkeditor/index.md
@@ -1,7 +1,9 @@
 ---
 title: msBulkEditor
 description: Bulk editing of MiniShop3 products in the MODX 3 manager
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msbulkeditor/logo.png
+modstore: https://modstore.pro/packages/ecommerce/msbulkeditor
 dependencies: [miniShop3, VueTools]
 categories: minishop3
 

--- a/docs/en/components/msbundles/index.md
+++ b/docs/en/components/msbundles/index.md
@@ -1,7 +1,9 @@
 ---
 title: msBundles
 description: Product bundles for miniShop3 with shared pricing, discounts, and cart sync
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msbundles/logo.png
+modstore: https://modstore.pro/packages/ecommerce/msbundles
 dependencies:
   - miniShop3
   - VueTools

--- a/docs/en/components/msp3yookassa/index.md
+++ b/docs/en/components/msp3yookassa/index.md
@@ -1,7 +1,9 @@
 ---
 title: msp3YooKassa
 description: YooKassa payments for MiniShop3 — one- and two-stage payments, webhooks, 54-FZ receipts
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msp3yookassa/logo.png
+modstore: https://modstore.pro/packages/payment-system/msp3yookassa
 dependencies: miniShop3
 categories: minishop3
 

--- a/docs/en/components/msptbank/index.md
+++ b/docs/en/components/msptbank/index.md
@@ -1,7 +1,9 @@
 ---
 title: mspTBank
 description: 'Приём оплаты через T-Bank для MiniShop3: redirect, webhook, чеки 54-ФЗ, одно- и двухстадийная схема, возвраты'
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msptbank/logo.png
+modstore: https://modstore.pro/packages/payment-system/msptbank
 dependencies: miniShop3
 categories: minishop3
 items:

--- a/docs/en/components/msreviews/index.md
+++ b/docs/en/components/msreviews/index.md
@@ -1,7 +1,7 @@
 ---
 title: msReviews
 description: Отзывы, рейтинг, Q&A и JSON-LD для MiniShop3
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/msreviews/logo.png
 modstore: https://modstore.pro/packages/ecommerce/msreviews
 dependencies: miniShop3

--- a/docs/en/components/msyandexdelivery/index.md
+++ b/docs/en/components/msyandexdelivery/index.md
@@ -1,11 +1,11 @@
 ---
 title: msYandexDelivery
 description: Yandex Delivery Platform API (other-day) for MiniShop3 — rates, pickup points, manager requests
-author: ibochkarev
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/msyandexdelivery/logo.png
+modstore: https://modstore.pro/packages/delivery/msyandexdelivery
 dependencies: [miniShop3, VueTools]
 categories: minishop3
-logo: https://modstore.pro/assets/extras/msyandexdelivery/logo-md.png
-modstore: https://modstore.pro/packages/delivery/msyandexdelivery
 items: [
   { text: 'Quick start', link: 'quick-start' },
   { text: 'System settings', link: 'settings' },

--- a/docs/en/components/mxeditorjs/index.md
+++ b/docs/en/components/mxeditorjs/index.md
@@ -1,7 +1,7 @@
 ---
 title: mxEditorJs
 description: Block editor Editor.js for MODX 3 — content in blocks instead of TinyMCE/CKEditor
-author: ibochkarev
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/mxeditorjs/logo.png
 modstore: https://modstore.pro/packages/content/mxeditorjs
 repository: https://github.com/Ibochkarev/mxEditorJs

--- a/docs/en/components/mxheadless/index.md
+++ b/docs/en/components/mxheadless/index.md
@@ -2,6 +2,8 @@
 title: mxHeadless
 description: REST API gateway for headless frontends on MODX 3. Resources, objects, OpenAPI, API keys, and OAuth
 author: Ibochkarev
+logo: https://modstore.pro/assets/extras/mxheadless/logo.png
+modstore: https://modstore.pro/packages/utilities/mxheadless
 repository: https://github.com/Ibochkarev/mxHeadless
 categories: utilities
 items: [

--- a/docs/en/components/mxquickview/index.md
+++ b/docs/en/components/mxquickview/index.md
@@ -1,8 +1,9 @@
 ---
 title: mxQuickView
 description: Quick view of product card and any resources via AJAX for MODX 3
-author: ibochkarev
-logo: https://modstore.pro/assets/extras/mxquickview/logo.jpg
+author: Ibochkarev
+logo: https://modstore.pro/assets/extras/mxquickview/logo.png
+modstore: https://modstore.pro/packages/ecommerce/mxquickview
 dependencies: ['minishop3', 'ms3Variants']
 
 items: [

--- a/docs/en/components/reactions/index.md
+++ b/docs/en/components/reactions/index.md
@@ -1,9 +1,10 @@
 ---
 title: Reactions
 description: Universal reactions for MODX 3 — likes, GitHub-style sets, tops and trending on any object
-author: ibochkarev
-repository: https://github.com/Ibochkarev/Reactions
+author: Ibochkarev
 logo: https://modstore.pro/assets/extras/reactions/logo.png
+modstore: https://modstore.pro/packages/ecommerce/reactions
+repository: https://github.com/Ibochkarev/Reactions
 categories: utilities
 
 items: [

--- a/docs/en/components/yandexmapslocator/index.md
+++ b/docs/en/components/yandexmapslocator/index.md
@@ -3,7 +3,7 @@ title: YandexMapsLocator
 description: 'Store locator on Yandex Maps for MODX 3. Free: map and search. Pro: open now, MiniShop3, CSV, and REST'
 author: Ibochkarev
 logo: https://modstore.pro/assets/extras/yandexmapslocator/logo.png
-modstore: https://modstore.pro/packages/utilities/yandexmapslocator
+modstore: https://modstore.pro/packages/maps/yandexmapslocator
 categories: utilities
 items: [
   {


### PR DESCRIPTION
Выравнивание frontmatter `logo` и `modstore` у компонентов автора Ibochkarev по актуальным ссылкам на [modstore.pro/authors/ibochkarev](https://modstore.pro/authors/ibochkarev).

Добавлены недостающие поля, исправлены неверные категории в URL (например `mscurrency` → `/integration/`, `geolocation2` и `yandexmapslocator` → `/maps/`), `author` нормализован до `Ibochkarev`. Предпочтение `logo.png`, если файл есть на CDN. У **msPriceTiers** логотипа на CDN нет, оставлен только `modstore`.

PageBuilder (`logo`/`modstore`) вынесен в отдельный PR #1035 вместе с обновлением 1.0.5.

## Чеклист перед отправкой

- [ ] `pnpm run lint` / `pnpm run spellcheck` (меняются только YAML-поля frontmatter)